### PR TITLE
Remove dependency on nose package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 env:
   global:
     - SETUP_XVFB=True
-    - CONDA_DEPENDENCIES="pytest matplotlib nose coverage"
+    - CONDA_DEPENDENCIES="pytest matplotlib coverage"
     - PIP_DEPENDENCIES="pytest-cov coveralls"
   matrix:
     - PYTHON_VERSION=2.6 MATPLOTLIB_VERSION=1.4 NUMPY_VERSION=1.9

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ For more information on how to write tests to do this, see the **Using** section
 Installing
 ----------
 
-This plugin is compatible with Python 2.6, 2.7, and 3.3 and later, and requires [pytest](http://pytest.org), [matplotlib](http://www.matplotlib.org) and
-[nose](http://nose.readthedocs.org/) to be installed (nose is required by Matplotlib).
+This plugin is compatible with Python 2.6, 2.7, and 3.3 and later, and requires
+[pytest](http://pytest.org) and [matplotlib](http://www.matplotlib.org) to be
+installed.
 
 To install, you can do:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,5 +33,5 @@ build: false
 
 test_script:
   - "%CMD_IN_ENV% cd tests"
+  - "%CMD_IN_ENV% python -c 'import pytest_mpl.plugin'"
   - "%CMD_IN_ENV% py.test --mpl -v"
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "pytest matplotlib nose"
+      CONDA_DEPENDENCIES: "pytest matplotlib"
 
   matrix:
       - PYTHON_VERSION: "2.6"

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -60,6 +60,7 @@ try:
     if not NOSE_INSTALLED:
         import imp
         sys.modules['nose'] = imp.new_module('nose')
+        sys.modules['nose.plugins.errorclass'] = imp.new_module('nose.plugins.errorclass')
 
     from matplotlib.testing.compare import compare_images
     from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
@@ -69,6 +70,7 @@ finally:
 
     if not NOSE_INSTALLED:
         sys.modules.pop('nose')
+        sys.modules.pop('nose.plugins.errorclass')
 
 # We don't use six in the following to avoid adding a dependency
 

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -41,9 +41,36 @@ import pytest
 
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.testing.compare import compare_images
-from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
-from matplotlib.testing.decorators import cleanup
+
+# The following imports in Matplotlib may require nose even though the
+# functionality we import doesn't require it. Therefore, if nose isn't
+# installed, we mock the module temporarily to avoid requiring it as a
+# dependency. We could in principle use the mock module but that would
+# then add a dependency.
+
+try:
+    import nose
+except ImportError:
+    NOSE_INSTALLED = False
+else:
+    NOSE_INSTALLED = True
+
+try:
+
+    if not NOSE_INSTALLED:
+        import imp
+        sys.modules['nose'] = imp.new_module('nose')
+
+    from matplotlib.testing.compare import compare_images
+    from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
+    from matplotlib.testing.decorators import cleanup
+
+finally:
+
+    if not NOSE_INSTALLED:
+        sys.modules.pop('nose')
+
+# We don't use six in the following to avoid adding a dependency
 
 if sys.version_info[0] == 2:
     from urllib import urlopen


### PR DESCRIPTION
This is a little hacky but avoids depending on nose (which isn't used anyway).

I've also done a PR to matplotlib to avoid this altogether (https://github.com/matplotlib/matplotlib/pull/6923), but we need to be compatible with older matplotlib versions so we can't avoid it.
