### PR TITLE
Remove dependency on nose for Matplotlib 2.0 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,11 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
 
+    # Remove nose if we are using Matplotlib 2.0. We force this here in case
+    # nose was installed as a conda dependency of matplotlib even if not
+    # specified explicitly.
+    - conda remove --no-pin --force nose || true
+
     # Need to use develop instead of install to make sure coverage works
     - python setup.py develop
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ For more information on how to write tests to do this, see the **Using** section
 Installing
 ----------
 
-This plugin is compatible with Python 2.6, 2.7, and 3.3 and later, and requires [pytest](http://pytest.org), [matplotlib](http://www.matplotlib.org) and
-[nose](http://nose.readthedocs.org/) to be installed (nose is required by Matplotlib).
+This plugin is compatible with Python 2.6, 2.7, and 3.3 and later, and requires
+[pytest](http://pytest.org), [matplotlib](http://www.matplotlib.org). When using
+Matplotlib versions earlier than 2.0, [nose](http://nose.readthedocs.org/) is
+also required.
 
 To install, you can do:
 

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -43,7 +43,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.testing.compare import compare_images
 from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
-from matplotlib.testing.decorators import cleanup
 
 if sys.version_info[0] == 2:
     from urllib import urlopen


### PR DESCRIPTION
Alternative to https://github.com/matplotlib/pytest-mpl/pull/28 - for now just remove nose dependency for Matplotlib 2.0 and higher.