### PR TITLE
Add PyPI classifiers to setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 *.egg
 *.egg-info
+.idea

--- a/LICENSE
+++ b/LICENSE
@@ -25,4 +25,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The code in this package includes code adapted from WCSAxes, which is released
 under a 3-clause BSD license and can be found here:
 
-  https://github.com/matplotlib/wcsaxes
+  https://github.com/astrofrog/wcsaxes

--- a/LICENSE
+++ b/LICENSE
@@ -25,4 +25,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The code in this package includes code adapted from WCSAxes, which is released
 under a 3-clause BSD license and can be found here:
 
-  https://github.com/astrofrog/wcsaxes
+  https://github.com/matplotlib/wcsaxes

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -26,7 +26,7 @@
 # The code below includes code adapted from WCSAxes, which is released
 # under a 3-clause BSD license and can be found here:
 #
-#   https://github.com/astrofrog/wcsaxes
+#   https://github.com/matplotlib/wcsaxes
 
 from functools import wraps
 
@@ -43,7 +43,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.testing.compare import compare_images
 from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
-from matplotlib.testing.decorators import cleanup
 
 if sys.version_info[0] == 2:
     from urllib import urlopen

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -26,7 +26,7 @@
 # The code below includes code adapted from WCSAxes, which is released
 # under a 3-clause BSD license and can be found here:
 #
-#   https://github.com/matplotlib/wcsaxes
+#   https://github.com/astrofrog/wcsaxes
 
 from functools import wraps
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sys
 from setuptools import setup
 
 from pytest_mpl import __version__
@@ -13,7 +12,7 @@ with open('README.rst') as infile:
 
 setup(
     version=__version__,
-    url="https://github.com/astrofrog/pytest-mpl",
+    url="https://github.com/matplotlib/pytest-mpl",
     name="pytest-mpl",
     description='pytest plugin to help with testing figures output from Matplotlib',
     long_description=long_description,
@@ -24,4 +23,16 @@ setup(
     author='Thomas Robitaille',
     author_email='thomas.robitaille@gmail.com',
     entry_points={'pytest11': ['pytest_mpl = pytest_mpl.plugin']},
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Framework :: Pytest',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Testing',
+        'Topic :: Scientific/Engineering :: Visualization',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        'Operating System :: OS Independent',
+        'License :: OSI Approved :: BSD License',
+    ],
 )


### PR DESCRIPTION
This PR adds PyPI classifiers to setup.py.

Especially "Framework :: Pytest" is useful IMO, it let's people find it as a Pytest plugin, see:
http://doc.pytest.org/en/latest/writing_plugins.html#making-your-plugin-installable-by-others
https://github.com/pytest-dev/cookiecutter-pytest-plugin/blob/master/pytest-%7B%7Bcookiecutter.plugin_name%7D%7D/setup.py#L27

I've also changed to the new `url="https://github.com/matplotlib/pytest-mpl"` and removed two unused imports.

I'll send a similar PR for `pytest-arraydiff` also.