### PR TITLE
Don't set a default style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 0.9 (unreleased)
 ----------------
 
-- No changes yet.
+- Changed so that style now doesn't default to 'classic' as some
+  packages might want to make sure their packages works well with
+  the default style (and it is easier to set a style than unset it).
 
 0.8 (2017-07-19)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -157,15 +157,19 @@ decorator takes precedence.
 Base style
 ^^^^^^^^^^
 
-By default, tests will be run using the Matplotlib 'classic' style
-(ignoring any locally defined RC parameters). This can be overriden by
-using the ``style`` argument:
+By default, tests will be run using the default Matplotlib style for the version
+you are using. (ignoring any locally defined RC parameters). If you want to use
+a constant style over time, this can be overriden by using the ``style``
+argument:
 
 .. code:: python
 
-    @pytest.mark.mpl_image_compare(style='fivethirtyeight')
+    @pytest.mark.mpl_image_compare(style='classic')
     def test_image():
         ...
+
+If you don't set a style, you will likely need to set a different baseline
+directory depending on the Matplotlib version being tested.
 
 Removing text
 ^^^^^^^^^^^^^

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -139,7 +139,7 @@ class ImageComparison(object):
 
         tolerance = compare.kwargs.get('tolerance', 2)
         savefig_kwargs = compare.kwargs.get('savefig_kwargs', {})
-        style = compare.kwargs.get('style', 'classic')
+        style = compare.kwargs.get('style', {})
         remove_text = compare.kwargs.get('remove_text', False)
         backend = compare.kwargs.get('backend', 'agg')
 


### PR DESCRIPTION
... since it's easier for people to set if needed than unset if not desired. We don't want people to be locked into 'classic' by default by Matplotlib 3.0! :wink:

This might break some CI for people using pytest-mpl, but I'd prefer to break things sooner rather than later. I'll try and find repos where pytest-mpl is used and inform them of the change.

cc @dopplershift @tacaswell - in case you have any objections