### PR TITLE
MNT: Avoid using deprecated remove_text

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -129,6 +129,10 @@ class ImageComparison(object):
         import matplotlib.pyplot as plt
         from matplotlib.testing.compare import compare_images
         from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
+        try:
+            from matplotlib.testing.decorators import remove_ticks_and_titles
+        except ImportError:
+            remove_ticks_and_titles = MplImageComparisonTest.remove_text
 
         MPL_LT_15 = LooseVersion(matplotlib.__version__) < LooseVersion('1.5')
 
@@ -178,7 +182,7 @@ class ImageComparison(object):
                     fig = original(*args, **kwargs)
 
                 if remove_text:
-                    MplImageComparisonTest.remove_text(fig)
+                    remove_ticks_and_titles(fig)
 
                 # Find test name to use as plot name
                 filename = compare.kwargs.get('filename', None)


### PR DESCRIPTION
Matplotlib 2.1 deprecated the remove_text staticmethod on
ImageComparisonTest. Try to use the standalone function, and fallback to
the method as needed.

Fixes #53 .