### PR TITLE
Allow baseline_dir to be comma-separated URL list to allow mirrors to be specified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 
 script:
    - python -c 'import pytest_mpl.plugin'
-   - py.test --mpl --cov pytest_mpl tests
+   - pytest -vv --mpl --cov pytest_mpl tests
    - python setup.py check --restructuredtext
 
 after_success:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 0.9 (unreleased)
 ----------------
 
-- No changes yet.
+- Allow baseline_dir to be comma-separated URL list to allow mirrors to
+  be specified. [#59]
 
 0.8 (2017-07-19)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,9 @@ filename of the plot (which defaults to the name of the test with a
 The baseline directory in the decorator above will be interpreted as
 being relative to the test file. Note that the baseline directory can
 also be a URL (which should start with ``http://`` or ``https://`` and
-end in a slash).
+end in a slash). If you want to specify mirrors, set ``baseline_dir`` to
+a comma-separated list of URLs (real commas in the URL should be encoded
+as ``%2C``).
 
 Finally, you can also set a custom baseline directory globally when
 running tests by running ``py.test`` with:

--- a/tests/test_pytest_mpl.py
+++ b/tests/test_pytest_mpl.py
@@ -39,6 +39,17 @@ def test_succeeds_remote():
     return fig
 
 
+# The following tries an invalid URL first (or at least a URL where the baseline
+# image won't exist), but should succeed with the second mirror.
+@pytest.mark.mpl_image_compare(baseline_dir='http://www.python.org,' + baseline_dir_remote,
+                               filename='test_succeeds_remote.png')
+def test_succeeds_faulty_mirror():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    ax.plot([1, 2, 3])
+    return fig
+
+
 class TestClass(object):
 
     @pytest.mark.mpl_image_compare(baseline_dir=baseline_dir_local)


### PR DESCRIPTION
Fixes #58 

This is to avoid issues such as https://github.com/astropy/astropy/issues/6573