### PR TITLE
Make sure running the tests without --mpl still results in figures getting closed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - PYTHON_VERSION=3.6 MATPLOTLIB_VERSION=2.0
 
     # The following build is meant to check that dependencies get set up correctly, but currently
-    # the image tests fail, which should be investigated. 
+    # the image tests fail, which should be investigated.
     # - PYTHON_VERSION=3.5 CONDA_DEPENDENCIES="coverage freetype libpng"
 
 install:
@@ -37,6 +37,9 @@ install:
 script:
    - python -c 'import pytest_mpl.plugin'
    - pytest -vv --mpl --cov pytest_mpl tests
+   # Make sure that the tests run ok even without the --mpl option (we close
+   # figures anyway in this case)
+   - pytest -vv --cov pytest_mpl --cov-append tests
    - python setup.py check --restructuredtext
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 env:
   global:
     - SETUP_XVFB=True
-    - CONDA_DEPENDENCIES="pytest matplotlib nose coverage"
+    - CONDA_DEPENDENCIES="pytest matplotlib nose coverage freetype=2.5.5"
     - PIP_DEPENDENCIES="pytest-cov coveralls"
   matrix:
     - PYTHON_VERSION=3.4 MATPLOTLIB_VERSION=1.5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,13 @@
 0.9 (unreleased)
 ----------------
 
+- Fix compatibility with Matplotlib 2.1. [#54]
+
 - Allow baseline_dir to be comma-separated URL list to allow mirrors to
   be specified. [#59]
 
-- Make sure figures get closed even if not running with the --mpl option.
+- Make sure figures get closed even if not running with the --mpl
+  option, and only close actual Matplotlib Figure objects. [#60]
 
 0.8 (2017-07-19)
 ----------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Allow baseline_dir to be comma-separated URL list to allow mirrors to
   be specified. [#59]
 
+- Make sure figures get closed even if not running with the --mpl option.
+
 0.8 (2017-07-19)
 ----------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,17 +10,16 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "pytest matplotlib nose"
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        MATPLOTLIB_VERSION: "1.5"
+        CONDA_DEPENDENCIES: "matplotlib=1.5 nose"
 
       - PYTHON_VERSION: "3.5"
-        MATPLOTLIB_VERSION: "1.5"
+        CONDA_DEPENDENCIES: "matplotlib=1.5 nose"
 
       - PYTHON_VERSION: "3.6"
-        MATPLOTLIB_VERSION: "2.0"
+        CONDA_DEPENDENCIES: "matplotlib=2.0 nose"
 
 platform:
     -x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
         CONDA_DEPENDENCIES: "matplotlib=1.5 nose"
 
       - PYTHON_VERSION: "3.6"
-        CONDA_DEPENDENCIES: "matplotlib=2.0 nose"
+        CONDA_DEPENDENCIES: "matplotlib=2.0.1 nose"
 
 platform:
     -x64

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -155,6 +155,7 @@ class ImageComparison(object):
 
         import matplotlib
         import matplotlib.pyplot as plt
+        from matplotlib.figure import Figure
         from matplotlib.testing.compare import compare_images
         from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
         try:
@@ -223,7 +224,13 @@ class ImageComparison(object):
                     test_image = os.path.abspath(os.path.join(result_dir, filename))
 
                     fig.savefig(test_image, **savefig_kwargs)
-                    plt.close(fig)
+
+                    # We only need to close actual Matplotlib figure objects. If
+                    # we are dealing with a figure-like object that provides
+                    # savefig but is not a real Matplotlib object, we shouldn't
+                    # try closing it here.
+                    if isinstance(fig, Figure):
+                        plt.close(fig)
 
                     # Find path to baseline image
                     if baseline_remote:
@@ -280,6 +287,7 @@ class FigureCloser(object):
             return
 
         import matplotlib.pyplot as plt
+        from matplotlib.figure import Figure
 
         original = item.function
 
@@ -291,7 +299,12 @@ class FigureCloser(object):
             else:  # function
                 fig = original(*args, **kwargs)
 
-            plt.close(fig)
+            # We only need to close actual Matplotlib figure objects. If
+            # we are dealing with a figure-like object that provides
+            # savefig but is not a real Matplotlib object, we shouldn't
+            # try closing it here.
+            if isinstance(fig, Figure):
+                plt.close(fig)
 
         if item.cls is not None:
             setattr(item.cls, item.function.__name__, item_function_wrapper)

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -34,6 +34,7 @@ import contextlib
 import os
 import sys
 import shutil
+import inspect
 import tempfile
 import warnings
 from distutils.version import LooseVersion
@@ -42,7 +43,7 @@ import pytest
 
 if sys.version_info[0] == 2:
     from urllib import urlopen
-    string_types = basestring
+    string_types = basestring  # noqa
 else:
     from urllib.request import urlopen
     string_types = str
@@ -70,7 +71,7 @@ def _download_file(baseline, filename):
 
 
 def pytest_addoption(parser):
-    group = parser.getgroup("general")
+    group = parser.getgroup("matplotlib image comparison")
     group.addoption('--mpl', action='store_true',
                     help="Enable comparison of matplotlib figures to reference files")
     group.addoption('--mpl-generate-path',
@@ -117,6 +118,10 @@ def pytest_configure(config):
                                                       generate_dir=generate_dir,
                                                       results_dir=results_dir))
 
+    else:
+
+        config.pluginmanager.register(FigureCloser(config))
+
 
 @contextlib.contextmanager
 def switch_backend(backend):
@@ -143,6 +148,11 @@ class ImageComparison(object):
 
     def pytest_runtest_setup(self, item):
 
+        compare = item.keywords.get('mpl_image_compare')
+
+        if compare is None:
+            return
+
         import matplotlib
         import matplotlib.pyplot as plt
         from matplotlib.testing.compare import compare_images
@@ -153,11 +163,6 @@ class ImageComparison(object):
             remove_ticks_and_titles = MplImageComparisonTest.remove_text
 
         MPL_LT_15 = LooseVersion(matplotlib.__version__) < LooseVersion('1.5')
-
-        compare = item.keywords.get('mpl_image_compare')
-
-        if compare is None:
-            return
 
         tolerance = compare.kwargs.get('tolerance', 2)
         savefig_kwargs = compare.kwargs.get('savefig_kwargs', {})
@@ -188,7 +193,6 @@ class ImageComparison(object):
             with plt.style.context(style), switch_backend(backend):
 
                 # Run test and get figure object
-                import inspect
                 if inspect.ismethod(original):  # method
                     # In some cases, for example if setup_method is used,
                     # original appears to belong to an instance of the test
@@ -252,6 +256,42 @@ class ImageComparison(object):
                     fig.savefig(os.path.abspath(os.path.join(self.generate_dir, filename)), **savefig_kwargs)
                     plt.close(fig)
                     pytest.skip("Skipping test, since generating data")
+
+        if item.cls is not None:
+            setattr(item.cls, item.function.__name__, item_function_wrapper)
+        else:
+            item.obj = item_function_wrapper
+
+
+class FigureCloser(object):
+    """
+    This is used in place of ImageComparison when the --mpl option is not used,
+    to make sure that we still close figures returned by tests.
+    """
+
+    def __init__(self, config):
+        self.config = config
+
+    def pytest_runtest_setup(self, item):
+
+        compare = item.keywords.get('mpl_image_compare')
+
+        if compare is None:
+            return
+
+        import matplotlib.pyplot as plt
+
+        original = item.function
+
+        @wraps(item.function)
+        def item_function_wrapper(*args, **kwargs):
+
+            if inspect.ismethod(original):  # method
+                fig = original.__func__(*args, **kwargs)
+            else:  # function
+                fig = original(*args, **kwargs)
+
+            plt.close(fig)
 
         if item.cls is not None:
             setattr(item.cls, item.function.__name__, item_function_wrapper)


### PR DESCRIPTION
This is to avoid memory issues.

cc @fmaussion

Fixes #56 and #57