### PR TITLE
Make sure local matplotlibrc files are completely ignored

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 0.10 (unreleased)
 -----------------
 
-- No changes yet.
+- Make sure local matplotlib files are completely ignored. [#64]
 
 0.9 (2017-10-12)
 ----------------

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -198,7 +198,7 @@ class ImageComparison(object):
                 if not baseline_remote:
                     baseline_dir = os.path.join(os.path.dirname(item.fspath.strpath), baseline_dir)
 
-            with plt.style.context(style), switch_backend(backend):
+            with plt.style.context(style, after_reset=True), switch_backend(backend):
 
                 # Run test and get figure object
                 if inspect.ismethod(original):  # method


### PR DESCRIPTION
This just adds ``after_reset=True`` to the context manager for the style