### PR TITLE
Move import of ImageComparisonTest to exception handler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.*.swp
 .tox
 .cache
 *.py[cod]

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -177,10 +177,10 @@ class ImageComparison(object):
         import matplotlib
         import matplotlib.pyplot as plt
         from matplotlib.testing.compare import compare_images
-        from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
         try:
             from matplotlib.testing.decorators import remove_ticks_and_titles
         except ImportError:
+            from matplotlib.testing.decorators import ImageComparisonTest as MplImageComparisonTest
             remove_ticks_and_titles = MplImageComparisonTest.remove_text
 
         MPL_LT_15 = LooseVersion(matplotlib.__version__) < LooseVersion('1.5')


### PR DESCRIPTION
This will allow Matplotlib to deprecate and ultimately remove
ImageComparisonTest (which is mostly pointless now, as a nose-runner
that uses pytest markers...).

Also allowed myself to add vim swap files to gitignore.