### PR TITLE
Fix warnings from updated pytest 3.6 marker API

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -157,6 +157,15 @@ def close_mpl_figure(fig):
         plt.close(fig)
 
 
+def get_marker(item, marker_name):
+    if hasattr(item, 'get_closest_marker'):
+        return item.get_closest_marker(marker_name)
+    else:
+        # "item.keywords.get" was deprecated in pytest 3.6
+        # See https://docs.pytest.org/en/latest/mark.html#updating-code
+        return item.keywords.get(marker_name)
+
+
 class ImageComparison(object):
 
     def __init__(self, config, baseline_dir=None, generate_dir=None, results_dir=None):
@@ -169,7 +178,7 @@ class ImageComparison(object):
 
     def pytest_runtest_setup(self, item):
 
-        compare = item.keywords.get('mpl_image_compare')
+        compare = get_marker(item, 'mpl_image_compare')
 
         if compare is None:
             return
@@ -295,7 +304,7 @@ class FigureCloser(object):
 
     def pytest_runtest_setup(self, item):
 
-        compare = item.keywords.get('mpl_image_compare')
+        compare = get_marker(item, 'mpl_image_compare')
 
         if compare is None:
             return


### PR DESCRIPTION
Use of *get_marker* was deprecated in py.test 3.6. See [Marker revamp and iteration ](https://docs.pytest.org/en/latest/mark.html#updating-code)

Tests with the decorator run correctly but are poluted with warnings such as:
```
tests/test_visualization.py::test_show_checkerboard_overlay
  /home/_/venvs/python3.6/site-packages/pytest_mpl/plugin.py:175: RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
  Please use node.get_closest_marker(name) or node.iter_markers(name).
  Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
    tolerance = compare.kwargs.get('tolerance', 2)
```

This patch fixes the issue by using get_closest_marker instead of the get_marker method.
