### PR TITLE
Add info to `pytest.fail` `msg` when image not found, to indicate `baseline_dir` where plugin was looking

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -262,9 +262,10 @@ class ImageComparison(object):
                         baseline_image_ref = os.path.abspath(os.path.join(os.path.dirname(item.fspath.strpath), baseline_dir, filename))
 
                     if not os.path.exists(baseline_image_ref):
-                        pytest.fail("Image file not found for comparison test. "
-                                    "(This is expected for new tests.)\nGenerated Image: "
-                                    "\n\t{test}".format(test=test_image), pytrace=False)
+                        pytest.fail("Image file not found for comparison test in: "
+                                    "\n\t{baseline_dir}"
+                                    "\n(This is expected for new tests.)\nGenerated Image: "
+                                    "\n\t{test}".format(baseline_dir=baseline_dir, test=test_image), pytrace=False)
 
                     # distutils may put the baseline images in non-accessible places,
                     # copy to our tmpdir to be sure to keep them in case of failure


### PR DESCRIPTION
Really simple change to `pytest.fail` `msg` for when the plugin fails to find the image at `baseline_dir`. I'm new to the plugin, and when attempting to use, I struggled for longer than I'd like to admit as to why the test could not find my image. 

My `baseline_dir` was located in my `tests` folder alongside the `test_figs.py` test file, as the instructions indicate to do after generating the baseline figures. The instructions also say (on my re-reading now) that the folder is "interpreted as being relative to the test file," but I foolishly was defining `@pytest.mark.mpl_image_compare(baseline_dir='tests/figs_baseline')`. 

Anyway, I only figured this out by modifying my installed version of pytest-mpl to determine where the plugin was searching. I'm not sure if anyone else follows my stupidity, but this would be a simple debugging tool for new users. Also might be helpful to add some emphasis to the README in this vein? Or a simple project structure example like below?

```
src/
  figure_maker.py
  tests/
    test_figure_maker.py
    baseline/
      test_figure_maker_fig1.png
      test_figure_maker_fig2.png
```
where `figure_maker.py` is a script or module that produces `fig1` and `fig2` during normal use.

Anyway, great plugin/utility, thanks!
AM
     
