### PR TITLE
Improve error message if shapes disagree

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=long_description,
     packages=['pytest_mpl'],
     package_data={'pytest_mpl': ['classic.mplstyle']},
-    install_requires=['pytest', 'matplotlib', 'nose'],
+    install_requires=['pytest', 'matplotlib', 'pillow', 'nose'],
     license='BSD',
     author='Thomas Robitaille',
     author_email='thomas.robitaille@gmail.com',


### PR DESCRIPTION
### Before:

```
        ...,
        [255, 255, 255],
        [255, 255, 255],
        [255, 255, 255]]], dtype=int16)
actualImage = array([[[255, 255, 255],
        [255, 255, 255],
        [255, 255, 255],
        ...,
        [255, 255, 255],
     ...[255, 255, 255],
        ...,
        [255, 255, 255],
        [255, 255, 255],
        [255, 255, 255]]], dtype=int16)

    def calculate_rms(expectedImage, actualImage):
        "Calculate the per-pixel errors, then compute the root mean square error."
        if expectedImage.shape != actualImage.shape:
            raise ImageComparisonFailure(
                "Image sizes do not match expected size: {} "
>               "actual size {}".format(expectedImage.shape, actualImage.shape))
E           matplotlib.testing.exceptions.ImageComparisonFailure: Image sizes do not match expected size: (153, 177, 3) actual size (146, 170, 3)

/usr/local/lib/python3.5/dist-packages/matplotlib/testing/compare.py:356: ImageComparisonFailure
```

### After:

```
Error: Image dimensions did not match.
  Expected shape: (800, 600)
    /var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmp9p8eizmu/baseline-test_succeeds.png
  Actual shape: (900, 900)
    /var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmp9p8eizmu/test_succeeds.png
```

The most important is that the file paths are now included.

Arguably this better error should be in ``compare_images`` but that would break the current behavior of raising an exception when the shapes don't match. Also, by adding it here it will work with all versions of Matplotlib.