### PR TITLE
Register mpl_image_compare marker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 - Improve error message if image shapes don't match. [#79]
 
+- Properly register mpl_image_compare marker with pytest. [#83]
+
 0.10 (2018-09-25)
 -----------------
 

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -104,6 +104,8 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
 
+    config.addinivalue_line('markers', "mpl_image_compare: Compares matplotlib figures against a baseline image")
+
     if config.getoption("--mpl") or config.getoption("--mpl-generate-path") is not None:
 
         baseline_dir = config.getoption("--mpl-baseline-path")


### PR DESCRIPTION
With pytest 4.5.0, I see a warning about this, which is fixed with the suggestion from @fredrikw in https://github.com/matplotlib/pytest-mpl/issues/69

Fixes https://github.com/matplotlib/pytest-mpl/issues/69