### PR TITLE
Relative path for baseline images

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -187,7 +187,13 @@ def get_marker(item, marker_name):
 
 class ImageComparison(object):
 
-    def __init__(self, config, baseline_dir=None, baseline_relative_dir=None, generate_dir=None, results_dir=None):
+    def __init__(self, 
+                 config, 
+                 baseline_dir=None, 
+                 baseline_relative_dir=None, 
+                 generate_dir=None, 
+                 results_dir=None
+                 ):
         self.config = config
         self.baseline_dir = baseline_dir
         self.baseline_relative_dir = baseline_relative_dir
@@ -236,7 +242,10 @@ class ImageComparison(object):
                 else:
                     if self.baseline_relative_dir:
                         # baseline dir is relative to the current test
-                        baseline_dir = os.path.join(os.path.dirname(item.fspath.strpath), self.baseline_relative_dir)
+                        baseline_dir = os.path.join(
+                            os.path.dirname(item.fspath.strpath), 
+                            self.baseline_relative_dir
+                        )
                     else:
                         # baseline dir is relative to where pytest was run
                         baseline_dir = self.baseline_dir

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -96,8 +96,8 @@ def pytest_addoption(parser):
                     "location where py.test is run unless --mpl-baseline-relative is given. "
                     "This can also be a URL or a set of comma-separated URLs (in case "
                     "mirrors are specified)", action='store')
-    group.addoption("--mpl-baseline-relative", help="interpret the baseline directory as relative "
-                    "to the test location.", action="store_true")
+    group.addoption("--mpl-baseline-relative", help="interpret the baseline directory as "
+                    "relative to the test location.", action="store_true")
 
     results_path_help = "directory for test results, relative to location where py.test is run"
     group.addoption('--mpl-results-path', help=results_path_help, action='store')

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -120,7 +120,7 @@ def pytest_configure(config):
             baseline_relative_dir = config.getoption("--mpl-baseline-path")
         else:
             baseline_relative_dir = None
-        
+
         # Note that results_dir is an empty string if not specified
         if not results_dir:
             results_dir = None
@@ -187,11 +187,11 @@ def get_marker(item, marker_name):
 
 class ImageComparison(object):
 
-    def __init__(self, 
-                 config, 
-                 baseline_dir=None, 
-                 baseline_relative_dir=None, 
-                 generate_dir=None, 
+    def __init__(self,
+                 config,
+                 baseline_dir=None,
+                 baseline_relative_dir=None,
+                 generate_dir=None,
                  results_dir=None
                  ):
         self.config = config
@@ -243,7 +243,7 @@ class ImageComparison(object):
                     if self.baseline_relative_dir:
                         # baseline dir is relative to the current test
                         baseline_dir = os.path.join(
-                            os.path.dirname(item.fspath.strpath), 
+                            os.path.dirname(item.fspath.strpath),
                             self.baseline_relative_dir
                         )
                     else:


### PR DESCRIPTION
Added the --mpl-baseline-relative option to have pytest_mpl interpret the path given in --mpl-baseline-path as a path relative to where the current test is, not relative to where pytest was run.

This allows setups where tests are arranged into a hierarchical structure to work.