### PR TITLE
Fix Travis CI builds by removing use of conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
 install:
   - if [[ $TRAVIS_OS_NAME != linux ]]; then
       git clone git://github.com/astropy/ci-helpers.git;
-      source ci-helpers/travis/setup_conda.sh;
+      source ci-helpers/travis/setup_python.sh;
     fi
 
 script:


### PR DESCRIPTION
This switches to using ``setup_python.sh`` which uses chocolatey on Windows and the native python.org installers on MacOS X