### PR TITLE
Include json test files in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include README.rst
 include CHANGES.md
 include tox.ini
 
-recursive-include tests *.py *.png
+recursive-include tests *.py *.json *.png
 recursive-include images *.png


### PR DESCRIPTION
The tests from the sdist fail because of missing `test_hash_lib.json`.