### PR TITLE
Print hash if figure test is new

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -470,7 +470,7 @@ class ImageComparison:
         test_hash = self.generate_image_hash(item, fig)
 
         if hash_name not in hash_library:
-            return (f"Hash for test '{hash_name}' not found in {hash_library_filename}.
+            return (f"Hash for test '{hash_name}' not found in {hash_library_filename}. "
                     f"Generated hash is {test_hash}.")
 
         if test_hash == hash_library[hash_name]:

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -466,11 +466,12 @@ class ImageComparison:
 
         hash_library = self.load_hash_library(hash_library_filename)
         hash_name = self.generate_test_name(item)
+        
+        test_hash = self.generate_image_hash(item, fig)
 
         if hash_name not in hash_library:
-            return f"Hash for test '{hash_name}' not found in {hash_library_filename}."
-
-        test_hash = self.generate_image_hash(item, fig)
+            return (f"Hash for test '{hash_name}' not found in {hash_library_filename}.
+                    f"Generated hash is {test_hash}.")
 
         if test_hash == hash_library[hash_name]:
             return


### PR DESCRIPTION
If a figure test isn't present in the hash library, still run the test and print the hash, so it's easy to add it to the library if it's a newly added test.