### PR TITLE
Improved result logging and JSON output

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -756,6 +756,9 @@ class ImageComparison:
             for test_name in sorted(self._test_results.keys()):
                 summary = self._test_results[test_name]
 
+                if not self.results_always and summary['result_image'] is None:
+                    continue  # Don't show test if no result image
+
                 if summary['rms'] is None and summary['tolerance'] is not None:
                     rms = (f'<div class="rms passed">\n'
                            f'  <strong>RMS:</strong> '

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -846,7 +846,7 @@ class ImageComparison:
                 summary = self.generate_summary_json()
                 print(f"A JSON report can be found at: {summary}")
             if 'html' in self.generate_summary:
-                summary = self.generate_summary_html(dir_list)
+                summary = self.generate_summary_html()
                 print(f"A summary of the failed tests can be found at: {summary}")
 
 


### PR DESCRIPTION
The PR improves the reporting of test results. Python dictionaries are used to record metrics (test result, RMS, hashes, error messages, image paths etc.) for each test while it is being run. This can be exported to JSON with `--mpl-generate-summary=json` (and also HTML with `--mpl-generate-summary=html,json`). The HTML output is now generated using the dictionaries, so extra info such as RMS and hashes are also shown in the HTML output.

PS: I'm also working on a Bootstrap webpage for a more interactive HTML output, which I'll open a separate PR for if/when this is merged. It could possibly replace `html`, with the current `html` output available at `simple-html`.