### PR TITLE
Force results-always when generating HTML

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -140,7 +140,8 @@ def pytest_addoption(parser):
     group.addoption('--mpl-results-path', help=results_path_help, action='store')
     parser.addini('mpl-results-path', help=results_path_help)
 
-    results_always_help = "Always generate result images, not just for failed tests."
+    results_always_help = ("Always generate result images, not just for failed tests. "
+                           "This option is automatically applied when generating a HTML summary.")
     group.addoption('--mpl-results-always', action='store_true',
                     help=results_always_help)
     parser.addini('mpl-results-always', help=results_always_help)
@@ -271,6 +272,9 @@ class ImageComparison:
             if len(unsupported_formats) > 0:
                 raise ValueError(f"The mpl summary type(s) '{sorted(unsupported_formats)}' "
                                  "are not supported.")
+            # Ignore `results_always` and always save result images for HTML output
+            if generate_summary & {'html', 'basic-html'}:
+                results_always = True
         self.generate_summary = generate_summary
         self.results_always = results_always
 


### PR DESCRIPTION
This ensures the HTML output always includes the images for the passed tests, and not empty boxes. (If anyone wants to only see failed tests in the HTML, the file can be accessed with `fig_comparison.html?f=overall-failed`.)