### PR TITLE
Remove Python 2 from package classifiers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ section below.
 Installing
 ----------
 
-This plugin is compatible with Python 2.7, and 3.6 and later, and
+This plugin is compatible with Python 3.6 and later, and
 requires `pytest <http://pytest.org>`__ and
 `matplotlib <http://www.matplotlib.org>`__ to be installed.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Topic :: Software Development :: Testing
     Topic :: Scientific/Engineering :: Visualization
     Programming Language :: Python
-    Programming Language :: Python :: 2
     Programming Language :: Python :: 3
     Operating System :: OS Independent
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
We already say `requires_python = >=3.6`