### PR TITLE
Downloadable hash library in HTML summary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 0.15 (unreleased)
 -----------------
 
+- An updated hash library will be saved to the results directory when
+  generating a HTML summary page or when the `--mpl-results-always` flag is
+  set. A button to download this file is included in the HTML summary.
+  Various bugfixes, test improvements and documentation updates. [#138]
 
 0.14 (2022-02-09)
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,10 @@ can either be specified via the ``--mpl-hash-library=`` command line argument,
 or via the ``hash_library=`` keyword argument to the
 ``@pytest.mark.mpl_image_compare`` decorator.
 
+When generating a hash library, the tests will also be run as usual against the
+existing hash library specified by ``--mpl-hash-library`` or the keyword argument.
+However, generating baseline images will always result in the tests being skipped.
+
 
 Hybrid Mode: Hashes and Images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -229,6 +229,12 @@ test (based on the hash library) also shown in the generated
 summary. This option is applied automatically when generating
 a HTML summary.
 
+When the ``--mpl-results-always`` option is active, and some hash
+comparison tests are performed, a hash library containing all the
+result hashes will also be saved to the root of the results directory.
+The filename will be extracted from ``--mpl-generate-hash-library``,
+``--mpl-hash-library`` or ``hash_library=`` in that order.
+
 Base style
 ^^^^^^^^^^
 

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -689,7 +689,8 @@ class ImageComparison:
             with open(hash_library_path, "w") as fp:
                 json.dump(self._generated_hash_library, fp, indent=2)
             if self.results_always:  # Make accessible in results directory
-                result_hash_library.name = hash_library_path.name  # use same name as generated
+                # Use same name as generated
+                result_hash_library = self.results_dir / hash_library_path.name
                 shutil.copy(hash_library_path, result_hash_library)
         elif self.results_always and self.results_hash_library_name:
             result_hashes = {k: v['result_hash'] for k, v in self._test_results.items()

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -700,14 +700,18 @@ class ImageComparison:
                     json.dump(result_hashes, fp, indent=2)
 
         if self.generate_summary:
+            kwargs = {}
             if 'json' in self.generate_summary:
                 summary = self.generate_summary_json()
                 print(f"A JSON report can be found at: {summary}")
+            if result_hash_library.exists():  # link to it in the HTML
+                kwargs["hash_library"] = result_hash_library.name
             if 'html' in self.generate_summary:
-                summary = generate_summary_html(self._test_results, self.results_dir)
+                summary = generate_summary_html(self._test_results, self.results_dir, **kwargs)
                 print(f"A summary of the failed tests can be found at: {summary}")
             if 'basic-html' in self.generate_summary:
-                summary = generate_summary_basic_html(self._test_results, self.results_dir)
+                summary = generate_summary_basic_html(self._test_results, self.results_dir,
+                                                      **kwargs)
                 print(f"A summary of the failed tests can be found at: {summary}")
 
 

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -181,8 +181,6 @@ def pytest_configure(config):
         if generate_dir is not None:
             if baseline_dir is not None:
                 warnings.warn("Ignoring --mpl-baseline-path since --mpl-generate-path is set")
-            if results_dir is not None and generate_dir is not None:
-                warnings.warn("Ignoring --mpl-result-path since --mpl-generate-path is set")
 
         if baseline_dir is not None and not baseline_dir.startswith(("https", "http")):
             baseline_dir = os.path.abspath(baseline_dir)

--- a/pytest_mpl/summary/html.py
+++ b/pytest_mpl/summary/html.py
@@ -117,7 +117,7 @@ class Result:
         elif self.baseline_image is None:
             return 'missing'
         else:
-            raise ValueError('Unknown image result.')
+            return 'generated'
 
     @cached_property
     def hash_status(self):
@@ -125,6 +125,8 @@ class Result:
         if self.baseline_hash is not None or self.result_hash is not None:
             if self.baseline_hash is None:
                 return 'missing'
+            elif self.result_hash is None:
+                return 'generated'
             elif self.baseline_hash == self.result_hash:
                 return 'match'
             else:
@@ -198,6 +200,7 @@ def status_class(status):
         'match': 'success',
         'diff': 'danger',
         'missing': 'warning',
+        'generated': 'warning',
     }
     return classes[status]
 
@@ -208,6 +211,7 @@ def image_status_msg(status):
         'match': 'Baseline image matches',
         'diff': 'Baseline image differs',
         'missing': 'Baseline image not found',
+        'generated': 'Baseline image was generated',
     }
     return messages[status]
 
@@ -218,6 +222,7 @@ def hash_status_msg(status):
         'match': 'Baseline hash matches',
         'diff': 'Baseline hash differs',
         'missing': 'Baseline hash not found',
+        'generated': 'Baseline hash was generated',
     }
     return messages[status]
 

--- a/pytest_mpl/summary/html.py
+++ b/pytest_mpl/summary/html.py
@@ -108,32 +108,6 @@ class Result:
         ]]
 
     @cached_property
-    def image_status(self):
-        """Status of the image comparison test."""
-        if self.rms is None and self.tolerance is not None:
-            return 'match'
-        elif self.rms is not None:
-            return 'diff'
-        elif self.baseline_image is None:
-            return 'missing'
-        else:
-            return 'generated'
-
-    @cached_property
-    def hash_status(self):
-        """Status of the hash comparison test."""
-        if self.baseline_hash is not None or self.result_hash is not None:
-            if self.baseline_hash is None:
-                return 'missing'
-            elif self.result_hash is None:
-                return 'generated'
-            elif self.baseline_hash == self.result_hash:
-                return 'match'
-            else:
-                return 'diff'
-        return None
-
-    @cached_property
     def indexes(self):
         """Dictionary with strings optimized for sorting."""
         return {'status': self._status_sort, 'rms': self._rms_sort}

--- a/pytest_mpl/summary/html.py
+++ b/pytest_mpl/summary/html.py
@@ -227,7 +227,7 @@ def hash_status_msg(status):
     return messages[status]
 
 
-def generate_summary_html(results, results_dir):
+def generate_summary_html(results, results_dir, hash_library=None):
     """Generate the HTML summary.
 
     Parameters
@@ -236,6 +236,9 @@ def generate_summary_html(results, results_dir):
         The `pytest_mpl.plugin.ImageComparison._test_results` object.
     results_dir : Path
         Path to the output directory.
+    hash_library : str, optional, default=None
+        Filename of the generated hash library at the root of `results_dir`.
+        Will be linked to in HTML if not None.
     """
 
     # Initialize Jinja
@@ -251,7 +254,7 @@ def generate_summary_html(results, results_dir):
 
     # Render HTML starting from the base template
     template = env.get_template("base.html")
-    html = template.render(results=Results(results))
+    html = template.render(results=Results(results), hash_library=hash_library)
 
     # Write files
     for file in ['styles.css', 'extra.js', 'hash.svg', 'image.svg']:
@@ -264,7 +267,7 @@ def generate_summary_html(results, results_dir):
     return html_file
 
 
-def generate_summary_basic_html(results, results_dir):
+def generate_summary_basic_html(results, results_dir, hash_library=None):
     """Generate the basic HTML summary.
 
     Parameters
@@ -273,6 +276,9 @@ def generate_summary_basic_html(results, results_dir):
         The `pytest_mpl.plugin.ImageComparison._test_results` object.
     results_dir : Path
         Path to the output directory.
+    hash_library : str, optional, default=None
+        Filename of the generated hash library at the root of `results_dir`.
+        Will be linked to in HTML if not None.
     """
 
     # Initialize Jinja
@@ -283,7 +289,7 @@ def generate_summary_basic_html(results, results_dir):
 
     # Render HTML starting from the base template
     template = env.get_template("basic.html")
-    html = template.render(results=Results(results))
+    html = template.render(results=Results(results), hash_library=hash_library)
 
     # Write files
     html_file = results_dir / 'fig_comparison_basic.html'

--- a/pytest_mpl/summary/templates/base.html
+++ b/pytest_mpl/summary/templates/base.html
@@ -8,7 +8,7 @@
           integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <title>{{ results.title }}</title>
 </head>
-<body{% if results.classes | length %} class="{{ results.classes | join(' ') }}"{% endif %} id="results">
+<body id="results">
 {% include 'navbar.html' %}
 <div class="album bg-light">
     <div class="container-fluid">

--- a/pytest_mpl/summary/templates/basic.html
+++ b/pytest_mpl/summary/templates/basic.html
@@ -48,6 +48,11 @@
     of those have a matching baseline image
     {%- endif %}
 </p>
+{% if hash_library -%}
+<p>
+    <a href="{{ hash_library }}" download>Download generated hash library</a>
+</p>
+{%- endif %}
 <table>
     <tr>
         <th></th>

--- a/pytest_mpl/summary/templates/extra.js
+++ b/pytest_mpl/summary/templates/extra.js
@@ -1,10 +1,3 @@
-// Remove all elements of class mpl-hash if hash test not run
-if (document.body.classList[0] == 'no-hash-test') {
-    document.querySelectorAll('.mpl-hash').forEach(function (elem) {
-        elem.parentElement.removeChild(elem);
-    });
-}
-
 // Enable tooltips
 var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
 var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {

--- a/pytest_mpl/summary/templates/filter.html
+++ b/pytest_mpl/summary/templates/filter.html
@@ -16,7 +16,7 @@
             {{ sort_option('status-sort', 'status', 'desc', default=true) }}
             {{ sort_option('collected-sort', 'collected', 'asc') }}
             {{ sort_option('test-name', 'name') }}
-            {% if results.warn_missing['baseline_image'] -%}
+            {% if results.image_comparison -%}
             {{ sort_option('rms-sort', 'RMS', 'desc') }}
             {%- endif %}
         </div>
@@ -34,15 +34,15 @@
                 {{ filter_option('overall-failed', 'failed') }}
                 {{ filter_option('overall-skipped', 'skipped') }}
             </div>
-            {% if results.warn_missing['baseline_image'] -%}
+            {% if results.image_comparison -%}
             <div class="list-group m-2">
                 {{ filter_option('image-match', 'matching images') }}
                 {{ filter_option('image-diff', 'differing images') }}
                 {{ filter_option('image-missing', 'no baseline image') }}
             </div>
             {%- endif %}
-            {% if results.warn_missing['baseline_hash'] -%}
-            <div class="list-group m-2 mpl-hash">
+            {% if results.hash_comparison -%}
+            <div class="list-group m-2">
                 {{ filter_option('hash-match', 'matching hashes') }}
                 {{ filter_option('hash-diff', 'differing hashes') }}
                 {{ filter_option('hash-missing', 'no baseline hash') }}

--- a/pytest_mpl/summary/templates/filter.html
+++ b/pytest_mpl/summary/templates/filter.html
@@ -62,5 +62,12 @@
                 </div>
             </div>
         </form>
+        {% if hash_library -%}
+        <hr>
+        <a download="{{ hash_library }}" href="{{ hash_library }}" class="btn btn-light"
+           data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true"
+           title="<pre>{{ hash_library }}</pre>"
+           role="button">Download generated hash library</a>
+        {%- endif %}
     </div>
 </div>

--- a/pytest_mpl/summary/templates/filter.html
+++ b/pytest_mpl/summary/templates/filter.html
@@ -62,12 +62,5 @@
                 </div>
             </div>
         </form>
-        {% if hash_library -%}
-        <hr>
-        <a download="{{ hash_library }}" href="{{ hash_library }}" class="btn btn-light"
-           data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true"
-           title="<pre>{{ hash_library }}</pre>"
-           role="button">Download generated hash library</a>
-        {%- endif %}
     </div>
 </div>

--- a/pytest_mpl/summary/templates/navbar.html
+++ b/pytest_mpl/summary/templates/navbar.html
@@ -9,6 +9,17 @@
                 <input class="form-control me-2 search" type="search" onblur="searchComplete()" placeholder="Search"
                        aria-label="Search">
             </form>
+            {% if hash_library -%}
+            <a download="{{ hash_library }}" href="{{ hash_library }}" class="btn btn-outline-secondary me-2"
+               data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true"
+               title="Download generated <pre>{{ hash_library }}</pre>"
+               role="button">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-hash"
+                     viewBox="0 0 16 16">
+                    <path d="M8.39 12.648a1.32 1.32 0 0 0-.015.18c0 .305.21.508.5.508.266 0 .492-.172.555-.477l.554-2.703h1.204c.421 0 .617-.234.617-.547 0-.312-.188-.53-.617-.53h-.985l.516-2.524h1.265c.43 0 .618-.227.618-.547 0-.313-.188-.524-.618-.524h-1.046l.476-2.304a1.06 1.06 0 0 0 .016-.164.51.51 0 0 0-.516-.516.54.54 0 0 0-.539.43l-.523 2.554H7.617l.477-2.304c.008-.04.015-.118.015-.164a.512.512 0 0 0-.523-.516.539.539 0 0 0-.531.43L6.53 5.484H5.414c-.43 0-.617.22-.617.532 0 .312.187.539.617.539h.906l-.515 2.523H4.609c-.421 0-.609.219-.609.531 0 .313.188.547.61.547h.976l-.516 2.492c-.008.04-.015.125-.015.18 0 .305.21.508.5.508.265 0 .492-.172.554-.477l.555-2.703h2.242l-.515 2.492zm-1-6.109h2.266l-.515 2.563H6.859l.532-2.563z"/>
+                </svg>
+            </a>
+            {%- endif %}
             <button class="btn btn-outline-primary" aria-label="Filter" type="button" data-bs-toggle="offcanvas"
                     data-bs-target="#offcanvasFilter" aria-controls="offcanvasFilter">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-funnel"

--- a/pytest_mpl/summary/templates/result.html
+++ b/pytest_mpl/summary/templates/result.html
@@ -17,8 +17,10 @@
                     <img src="{{ r.result_image }}" class="card-img-top" alt="result image">
                 </div>
             </div>
-            {%- else -%}
+            {%- elif r.result_image -%}
             <img src="{{ r.result_image }}" class="card-img-top" alt="result image">
+            {%- elif r.baseline_image -%}
+            <img src="{{ r.baseline_image }}" class="card-img-top" alt="baseline image">
             {%- endif %}
         </a>
         {% filter indent(width=8) -%}

--- a/pytest_mpl/summary/templates/result_images.html
+++ b/pytest_mpl/summary/templates/result_images.html
@@ -6,14 +6,14 @@
     </div>
     <div class="offcanvas-body">
         <h5 class="card-title">{{ r.name }}</h5>
-        {% if results.warn_missing['baseline_image'] and r.image_status != 'generated' -%}
+        {% if r.image_status and r.image_status != 'generated' -%}
         <div class="row row-cols-1 row-cols-md-3 g-4 mt-3">
             {% macro image_card(file, name) -%}
             <div class="col py-3 m-0">
                 <div class="card h-100">
                     <div class="card-header">{{ name }}</div>
                     {% if file -%}
-                    <img src="{{ file }}" class="card-img-top" alt="">
+                    <img src="{{ file }}" class="card-img-top" alt="{{ name }}">
                     {%- endif %}
                 </div>
             </div>
@@ -41,21 +41,25 @@
                 </div>
                 {%- endfilter %}
                 {%- endmacro -%}
-                {% if results.warn_missing['baseline_image'] -%}
-                <div class="card text-white bg-{{ r.image_status | status_class }} mb-3 mpl-image">
+                {% if r.image_status -%}
+                <div class="card text-white bg-{{ r.image_status | status_class }} mb-3">
                     <div class="card-header">{{ r.image_status | image_status_msg }}</div>
+                    {% if r.image_status == 'match' or r.image_status == 'diff' -%}
                     <div class="card-body">
                         {{ pre_data('rms', r.rms_str, 'RMS') }}
                         {{ pre_data('tolerance', r.tolerance, 'Tolerance') }}
                     </div>
+                    {%- endif %}
                 </div>
                 {%- endif %}
-                {% if results.warn_missing['baseline_hash'] -%}
-                <div class="card text-white bg-{{ r.hash_status | status_class }} mb-3 mpl-hash">
+                {% if r.hash_status -%}
+                <div class="card text-white bg-{{ r.hash_status | status_class }} mb-3">
                     <div class="card-header">{{ r.hash_status | hash_status_msg }}</div>
                     <div class="card-body">
                         {{ pre_data('baseline_hash', r.baseline_hash, 'Baseline') }}
+                        {% if r.hash_status != 'generated' -%}
                         {{ pre_data('result_hash', r.result_hash, 'Result') }}
+                        {%- endif %}
                     </div>
                 </div>
                 {%- endif %}

--- a/pytest_mpl/summary/templates/result_images.html
+++ b/pytest_mpl/summary/templates/result_images.html
@@ -6,7 +6,7 @@
     </div>
     <div class="offcanvas-body">
         <h5 class="card-title">{{ r.name }}</h5>
-        {% if results.warn_missing['baseline_image'] -%}
+        {% if results.warn_missing['baseline_image'] and r.image_status != 'generated' -%}
         <div class="row row-cols-1 row-cols-md-3 g-4 mt-3">
             {% macro image_card(file, name) -%}
             <div class="col py-3 m-0">

--- a/pytest_mpl/summary/templates/styles.css
+++ b/pytest_mpl/summary/templates/styles.css
@@ -35,6 +35,9 @@ body.no-hash-test .mpl-hash {
 pre {
     white-space: pre-line;
 }
+.tooltip-inner pre {
+    margin: 0;
+}
 div.result div.status-badge button img {
     vertical-align: sub;
 }

--- a/pytest_mpl/summary/templates/styles.css
+++ b/pytest_mpl/summary/templates/styles.css
@@ -1,6 +1,3 @@
-body.no-hash-test .mpl-hash {
-    display: none;
-}
 .navbar-brand span.repo {
     font-weight: bold;
 }
@@ -28,9 +25,6 @@ body.no-hash-test .mpl-hash {
     .nav-filtertools .nav-searchbar {
         max-width: 400px;
     }
-}
-.image-missing .mpl-image .card-body {
-    display: none;
 }
 pre {
     white-space: pre-line;

--- a/pytest_mpl/summary/templates/styles.css
+++ b/pytest_mpl/summary/templates/styles.css
@@ -11,6 +11,9 @@
 .nav-filtertools .nav-searchbar {
     flex: 10;
 }
+.nav-filtertools svg {
+    vertical-align: text-bottom;
+}
 #filterForm .spacer {
     flex: 1;
 }

--- a/tests/subtests/helpers.py
+++ b/tests/subtests/helpers.py
@@ -9,7 +9,8 @@ class MatchError(Exception):
     pass
 
 
-def diff_summary(baseline, result, baseline_hash_library=None, result_hash_library=None):
+def diff_summary(baseline, result, baseline_hash_library=None, result_hash_library=None,
+                 generating_hashes=False):
     """Diff a pytest-mpl summary dictionary.
 
     Parameters
@@ -26,6 +27,9 @@ def diff_summary(baseline, result, baseline_hash_library=None, result_hash_libra
         Path to the "baseline" image hash library.
         Result hashes in the baseline summary are updated to these values
         to handle different Matplotlib versions.
+    generating_hashes : bool, optional, default=False
+        Whether `--mpl-generate-hash-library` was specified and
+        both of `--mpl-hash-library` and `hash_library=` were not.
     """
     if baseline_hash_library and baseline_hash_library.exists():
         # Load "correct" baseline hashes
@@ -57,10 +61,13 @@ def diff_summary(baseline, result, baseline_hash_library=None, result_hash_libra
 
         # Swap the baseline and result hashes in the summary
         # for the corresponding hashes in each hash library
-        if baseline_hash_library and test in baseline_hash_library:
+        if baseline_hash_library and test in baseline_hash_library and not generating_hashes:
             baseline_summary = replace_hash(baseline_summary, 'baseline_hash',
                                             baseline_hash_library[test])
         if result_hash_library:
+            if generating_hashes:  # Newly generate result will appear as baseline_hash
+                baseline_summary = replace_hash(baseline_summary, 'baseline_hash',
+                                                result_hash_library[test])
             baseline_summary = replace_hash(baseline_summary, 'result_hash',
                                             result_hash_library[test])
 

--- a/tests/subtests/summaries/test_default.json
+++ b/tests/subtests/summaries/test_default.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": null,
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmatch_idiff/result-failed-diff.png",
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": null,
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -34,6 +40,8 @@
   },
   "subtests.subtest.test_hdiff_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -45,6 +53,8 @@
   },
   "subtests.subtest.test_hdiff_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": null,
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff/result-failed-diff.png",
@@ -56,6 +66,8 @@
   },
   "subtests.subtest.test_hdiff_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": null,
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -67,6 +79,8 @@
   },
   "subtests.subtest.test_hmissing_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -78,6 +92,8 @@
   },
   "subtests.subtest.test_hmissing_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": null,
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 12\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmissing_idiff/result-failed-diff.png",
@@ -89,6 +105,8 @@
   },
   "subtests.subtest.test_hmissing_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": null,
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -100,6 +118,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -111,6 +131,8 @@
   },
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": null,
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 29\\.2[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    3",
     "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff_tolerance/result-failed-diff.png",
@@ -122,6 +144,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -133,6 +157,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -144,6 +170,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,

--- a/tests/subtests/summaries/test_generate.json
+++ b/tests/subtests/summaries/test_generate.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -34,6 +40,8 @@
   },
   "subtests.subtest.test_hdiff_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -45,6 +53,8 @@
   },
   "subtests.subtest.test_hdiff_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -56,6 +66,8 @@
   },
   "subtests.subtest.test_hdiff_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -67,6 +79,8 @@
   },
   "subtests.subtest.test_hmissing_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -78,6 +92,8 @@
   },
   "subtests.subtest.test_hmissing_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -89,6 +105,8 @@
   },
   "subtests.subtest.test_hmissing_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -100,6 +118,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -111,6 +131,8 @@
   },
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -122,6 +144,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -133,6 +157,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -144,6 +170,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,

--- a/tests/subtests/summaries/test_generate.json
+++ b/tests/subtests/summaries/test_generate.json
@@ -1,0 +1,156 @@
+{
+  "subtests.subtest.test_hmatch_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "4a47c9b7920779cc83eabe2bbb64b9c40745d9d8abfa57857f93a5d8f12a5a03",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "2b48790b0a2cee4b41cdb9820336acaf229ba811ae21c6a92b4b92838843adfa",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "e937fa1997d088c904ca35b1ab542e2285ea47b84df976490380f9c5f5b5f8ae",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "2cae8f315d44b06de8f45d937af46a67bd1389edd6e4cde32f9feb4b7472284f",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "927521206ef454a25417e3ba0bd3235c84518cb202c2d1fa7afcfdfcde5fdcde",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "afc411cfa34db3a5819ac4127704e86acf27d24d1ea2410718853d3d7e1d6ae0",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "7ee8370efdc4b767634d12355657ca4f2460176670c07b31f3fb72cea0e79856",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "4eeda1d349f4b0f26df97df41ba5410dce2b1c7ed520062d58f3c5f0e3790ebd",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "5101e60ac100cf2c2f418a0a6a382aae0060339e76718730344f539b61f7dc7e",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_tolerance": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "510b3273d63a2a26a27e788ff0f090e86c9df7f9f191b7c566321c57de8266d6",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff_tolerance": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "510b3273d63a2a26a27e788ff0f090e86c9df7f9f191b7c566321c57de8266d6",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_savefig": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "8864803a4b4026d8c6dc0ab950228793ea255cd9b6c629c39db9e6315a9af6bc",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_style": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "e3c8de36c2bad7dca131e4cbbfe229f882b5beec62750fb7da29314fd6a1ff13",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_removetext": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "e4c06cf613c6836c1b1202abaae69cf65bc2232a8e31ab1040454bedc8e31e7a",
+    "result_hash": null
+  }
+}

--- a/tests/subtests/summaries/test_generate_hashes_only.json
+++ b/tests/subtests/summaries/test_generate_hashes_only.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": "generated",
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmatch_idiff/result-failed-diff.png",
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": "generated",
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -34,6 +40,8 @@
   },
   "subtests.subtest.test_hdiff_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -45,6 +53,8 @@
   },
   "subtests.subtest.test_hdiff_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": "generated",
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff/result-failed-diff.png",
@@ -56,6 +66,8 @@
   },
   "subtests.subtest.test_hdiff_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": "generated",
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -67,6 +79,8 @@
   },
   "subtests.subtest.test_hmissing_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -78,6 +92,8 @@
   },
   "subtests.subtest.test_hmissing_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": "generated",
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 12\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmissing_idiff/result-failed-diff.png",
@@ -89,6 +105,8 @@
   },
   "subtests.subtest.test_hmissing_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": "generated",
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -100,6 +118,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -111,6 +131,8 @@
   },
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": "generated",
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 29\\.2[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    3",
     "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff_tolerance/result-failed-diff.png",
@@ -122,6 +144,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -133,6 +157,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,
@@ -144,6 +170,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": null,
     "diff_image": null,

--- a/tests/subtests/summaries/test_generate_hashes_only.json
+++ b/tests/subtests/summaries/test_generate_hashes_only.json
@@ -1,0 +1,156 @@
+{
+  "subtests.subtest.test_hmatch_imatch": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": null,
+    "baseline_hash": "4a47c9b7920779cc83eabe2bbb64b9c40745d9d8abfa57857f93a5d8f12a5a03",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_idiff": {
+    "status": "failed",
+    "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
+    "diff_image": "subtests.subtest.test_hmatch_idiff/result-failed-diff.png",
+    "rms": 11.100353848213828,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hmatch_idiff/result.png",
+    "baseline_hash": "2b48790b0a2cee4b41cdb9820336acaf229ba811ae21c6a92b4b92838843adfa",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_imissing": {
+    "status": "failed",
+    "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": "subtests.subtest.test_hmatch_imissing/result.png",
+    "baseline_hash": "e937fa1997d088c904ca35b1ab542e2285ea47b84df976490380f9c5f5b5f8ae",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": null,
+    "baseline_hash": "2cae8f315d44b06de8f45d937af46a67bd1389edd6e4cde32f9feb4b7472284f",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff": {
+    "status": "failed",
+    "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
+    "diff_image": "subtests.subtest.test_hdiff_idiff/result-failed-diff.png",
+    "rms": 11.182677079602481,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hdiff_idiff/result.png",
+    "baseline_hash": "927521206ef454a25417e3ba0bd3235c84518cb202c2d1fa7afcfdfcde5fdcde",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imissing": {
+    "status": "failed",
+    "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": "subtests.subtest.test_hdiff_imissing/result.png",
+    "baseline_hash": "afc411cfa34db3a5819ac4127704e86acf27d24d1ea2410718853d3d7e1d6ae0",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imatch": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": null,
+    "baseline_hash": "7ee8370efdc4b767634d12355657ca4f2460176670c07b31f3fb72cea0e79856",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_idiff": {
+    "status": "failed",
+    "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 12\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
+    "diff_image": "subtests.subtest.test_hmissing_idiff/result-failed-diff.png",
+    "rms": 12.12938597648977,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hmissing_idiff/result.png",
+    "baseline_hash": "4eeda1d349f4b0f26df97df41ba5410dce2b1c7ed520062d58f3c5f0e3790ebd",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imissing": {
+    "status": "failed",
+    "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": "subtests.subtest.test_hmissing_imissing/result.png",
+    "baseline_hash": "5101e60ac100cf2c2f418a0a6a382aae0060339e76718730344f539b61f7dc7e",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_tolerance": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 200,
+    "result_image": null,
+    "baseline_hash": "510b3273d63a2a26a27e788ff0f090e86c9df7f9f191b7c566321c57de8266d6",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff_tolerance": {
+    "status": "failed",
+    "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 29\\.2[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    3",
+    "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
+    "diff_image": "subtests.subtest.test_hdiff_idiff_tolerance/result-failed-diff.png",
+    "rms": 29.260332173249314,
+    "tolerance": 3,
+    "result_image": "subtests.subtest.test_hdiff_idiff_tolerance/result.png",
+    "baseline_hash": "510b3273d63a2a26a27e788ff0f090e86c9df7f9f191b7c566321c57de8266d6",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_savefig": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": null,
+    "baseline_hash": "8864803a4b4026d8c6dc0ab950228793ea255cd9b6c629c39db9e6315a9af6bc",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_style": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": null,
+    "baseline_hash": "e3c8de36c2bad7dca131e4cbbfe229f882b5beec62750fb7da29314fd6a1ff13",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_removetext": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": null,
+    "baseline_hash": "e4c06cf613c6836c1b1202abaae69cf65bc2232a8e31ab1040454bedc8e31e7a",
+    "result_hash": null
+  }
+}

--- a/tests/subtests/summaries/test_generate_images_only.json
+++ b/tests/subtests/summaries/test_generate_images_only.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -34,6 +40,8 @@
   },
   "subtests.subtest.test_hdiff_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -45,6 +53,8 @@
   },
   "subtests.subtest.test_hdiff_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -56,6 +66,8 @@
   },
   "subtests.subtest.test_hdiff_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -67,6 +79,8 @@
   },
   "subtests.subtest.test_hmissing_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -78,6 +92,8 @@
   },
   "subtests.subtest.test_hmissing_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -89,6 +105,8 @@
   },
   "subtests.subtest.test_hmissing_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -100,6 +118,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -111,6 +131,8 @@
   },
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -122,6 +144,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -133,6 +157,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,
@@ -144,6 +170,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": null,
     "diff_image": null,

--- a/tests/subtests/summaries/test_generate_images_only.json
+++ b/tests/subtests/summaries/test_generate_images_only.json
@@ -1,0 +1,156 @@
+{
+  "subtests.subtest.test_hmatch_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_tolerance": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff_tolerance": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_savefig": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_style": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_removetext": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  }
+}

--- a/tests/subtests/summaries/test_hash.json
+++ b/tests/subtests/summaries/test_hash.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -35,6 +41,8 @@
   "subtests.subtest.test_hdiff_imatch": {
     "status": "failed",
     "status_msg": "REGEX:Hash 6e2fdde5a6682dc6abba7121f5df702c3664b1ce09593534fc0d7c3514eb07e1 doesn't match hash d1ffdde5a6682dc6abba7121f5df702c3664b1ce09593534fc0d7c3514eb07e1 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -46,6 +54,8 @@
   "subtests.subtest.test_hdiff_idiff": {
     "status": "failed",
     "status_msg": "REGEX:Hash 443361bdd0efd1cdd343eabf73af6f20439d4834ab5503a574ac7ec28e0c2b43 doesn't match hash d1ff61bdd0efd1cdd343eabf73af6f20439d4834ab5503a574ac7ec28e0c2b43 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_idiff\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -57,6 +67,8 @@
   "subtests.subtest.test_hdiff_imissing": {
     "status": "failed",
     "status_msg": "REGEX:Hash 301e63d656d7a586cc4e498bc32b970f8cb7c7c47bbd2fec33b931219fc0690e doesn't match hash d1ff63d656d7a586cc4e498bc32b970f8cb7c7c47bbd2fec33b931219fc0690e in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imissing\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -68,6 +80,8 @@
   "subtests.subtest.test_hmissing_imatch": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_imatch' not found in .*\\.json\\. Generated hash is eabd8a2e22afd88682990bfb8e4a0700a942fe68e5114e8da4ab6bd93c47b824\\.",
+    "image_status": null,
+    "hash_status": "missing",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -79,6 +93,8 @@
   "subtests.subtest.test_hmissing_idiff": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_idiff' not found in .*\\.json\\. Generated hash is e69570c4a70b2cc88ddee0f0a82312cae4f394b7f62e5760245feda1364c03ab\\.",
+    "image_status": null,
+    "hash_status": "missing",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -90,6 +106,8 @@
   "subtests.subtest.test_hmissing_imissing": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_imissing' not found in .*\\.json\\. Generated hash is 5c8a9c7412e4e098f6f2683ee247c08bd50805a93df4d4b6d8fccf3579b4c56b\\.",
+    "image_status": null,
+    "hash_status": "missing",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -101,6 +119,8 @@
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "failed",
     "status_msg": "REGEX:Hash aaf4e85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 doesn't match hash d1ffe85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_tolerance\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -112,6 +132,8 @@
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "failed",
     "status_msg": "REGEX:Hash aaf4e85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 doesn't match hash d1ffe85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_idiff_tolerance\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -123,6 +145,8 @@
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "failed",
     "status_msg": "REGEX:Hash 5dc1c2c68c2d34c03a89ab394e3c11349b76594d0c8837374daef299ac227568 doesn't match hash d1ffc2c68c2d34c03a89ab394e3c11349b76594d0c8837374daef299ac227568 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_savefig\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -134,6 +158,8 @@
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "failed",
     "status_msg": "REGEX:Hash 185ed1b702c7bbd810370b12e46ecea4b9c9eb87b743397f1d4a50177e7ba7f7 doesn't match hash d1ffd1b702c7bbd810370b12e46ecea4b9c9eb87b743397f1d4a50177e7ba7f7 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_style\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -145,6 +171,8 @@
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "failed",
     "status_msg": "REGEX:Hash be5af83a43cb89f5e13923f532fe5c9bedbf7d13585533efef2f4051c4968b5e doesn't match hash d1fff83a43cb89f5e13923f532fe5c9bedbf7d13585533efef2f4051c4968b5e in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_removetext\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,

--- a/tests/subtests/summaries/test_html_generate.json
+++ b/tests/subtests/summaries/test_html_generate.json
@@ -1,0 +1,156 @@
+{
+  "subtests.subtest.test_hmatch_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmatch_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "4a47c9b7920779cc83eabe2bbb64b9c40745d9d8abfa57857f93a5d8f12a5a03",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "2b48790b0a2cee4b41cdb9820336acaf229ba811ae21c6a92b4b92838843adfa",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmatch_imissing/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "e937fa1997d088c904ca35b1ab542e2285ea47b84df976490380f9c5f5b5f8ae",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "2cae8f315d44b06de8f45d937af46a67bd1389edd6e4cde32f9feb4b7472284f",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "927521206ef454a25417e3ba0bd3235c84518cb202c2d1fa7afcfdfcde5fdcde",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imissing/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "afc411cfa34db3a5819ac4127704e86acf27d24d1ea2410718853d3d7e1d6ae0",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "7ee8370efdc4b767634d12355657ca4f2460176670c07b31f3fb72cea0e79856",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "4eeda1d349f4b0f26df97df41ba5410dce2b1c7ed520062d58f3c5f0e3790ebd",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmissing_imissing/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "5101e60ac100cf2c2f418a0a6a382aae0060339e76718730344f539b61f7dc7e",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_tolerance": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "510b3273d63a2a26a27e788ff0f090e86c9df7f9f191b7c566321c57de8266d6",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff_tolerance": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "510b3273d63a2a26a27e788ff0f090e86c9df7f9f191b7c566321c57de8266d6",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_savefig": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "8864803a4b4026d8c6dc0ab950228793ea255cd9b6c629c39db9e6315a9af6bc",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_style": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "e3c8de36c2bad7dca131e4cbbfe229f882b5beec62750fb7da29314fd6a1ff13",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_removetext": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": "e4c06cf613c6836c1b1202abaae69cf65bc2232a8e31ab1040454bedc8e31e7a",
+    "result_hash": null
+  }
+}

--- a/tests/subtests/summaries/test_html_generate.json
+++ b/tests/subtests/summaries/test_html_generate.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmatch_imatch/baseline.png",
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
     "diff_image": null,
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmatch_imissing/baseline.png",
     "diff_image": null,
@@ -34,6 +40,8 @@
   },
   "subtests.subtest.test_hdiff_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
     "diff_image": null,
@@ -45,6 +53,8 @@
   },
   "subtests.subtest.test_hdiff_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
     "diff_image": null,
@@ -56,6 +66,8 @@
   },
   "subtests.subtest.test_hdiff_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imissing/baseline.png",
     "diff_image": null,
@@ -67,6 +79,8 @@
   },
   "subtests.subtest.test_hmissing_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
     "diff_image": null,
@@ -78,6 +92,8 @@
   },
   "subtests.subtest.test_hmissing_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
     "diff_image": null,
@@ -89,6 +105,8 @@
   },
   "subtests.subtest.test_hmissing_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmissing_imissing/baseline.png",
     "diff_image": null,
@@ -100,6 +118,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
     "diff_image": null,
@@ -111,6 +131,8 @@
   },
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
     "diff_image": null,
@@ -122,6 +144,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
     "diff_image": null,
@@ -133,6 +157,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
     "diff_image": null,
@@ -144,6 +170,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": "generated",
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
     "diff_image": null,

--- a/tests/subtests/summaries/test_html_generate_hashes_only.json
+++ b/tests/subtests/summaries/test_html_generate_hashes_only.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hmatch_imatch/baseline.png",
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": "generated",
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmatch_idiff/result-failed-diff.png",
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": "generated",
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -34,6 +40,8 @@
   },
   "subtests.subtest.test_hdiff_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
     "diff_image": null,
@@ -45,6 +53,8 @@
   },
   "subtests.subtest.test_hdiff_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": "generated",
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff/result-failed-diff.png",
@@ -56,6 +66,8 @@
   },
   "subtests.subtest.test_hdiff_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": "generated",
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -67,6 +79,8 @@
   },
   "subtests.subtest.test_hmissing_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
     "diff_image": null,
@@ -78,6 +92,8 @@
   },
   "subtests.subtest.test_hmissing_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": "generated",
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 12\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmissing_idiff/result-failed-diff.png",
@@ -89,6 +105,8 @@
   },
   "subtests.subtest.test_hmissing_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": "generated",
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -100,6 +118,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
     "diff_image": null,
@@ -111,6 +131,8 @@
   },
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": "generated",
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 29\\.2[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    3",
     "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff_tolerance/result-failed-diff.png",
@@ -122,6 +144,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
     "diff_image": null,
@@ -133,6 +157,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
     "diff_image": null,
@@ -144,6 +170,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "generated",
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
     "diff_image": null,

--- a/tests/subtests/summaries/test_html_generate_hashes_only.json
+++ b/tests/subtests/summaries/test_html_generate_hashes_only.json
@@ -1,0 +1,156 @@
+{
+  "subtests.subtest.test_hmatch_imatch": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": "subtests.subtest.test_hmatch_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hmatch_imatch/result.png",
+    "baseline_hash": "4a47c9b7920779cc83eabe2bbb64b9c40745d9d8abfa57857f93a5d8f12a5a03",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_idiff": {
+    "status": "failed",
+    "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
+    "diff_image": "subtests.subtest.test_hmatch_idiff/result-failed-diff.png",
+    "rms": 11.100353848213828,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hmatch_idiff/result.png",
+    "baseline_hash": "2b48790b0a2cee4b41cdb9820336acaf229ba811ae21c6a92b4b92838843adfa",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_imissing": {
+    "status": "failed",
+    "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": "subtests.subtest.test_hmatch_imissing/result.png",
+    "baseline_hash": "e937fa1997d088c904ca35b1ab542e2285ea47b84df976490380f9c5f5b5f8ae",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hdiff_imatch/result.png",
+    "baseline_hash": "2cae8f315d44b06de8f45d937af46a67bd1389edd6e4cde32f9feb4b7472284f",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff": {
+    "status": "failed",
+    "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
+    "diff_image": "subtests.subtest.test_hdiff_idiff/result-failed-diff.png",
+    "rms": 11.182677079602481,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hdiff_idiff/result.png",
+    "baseline_hash": "927521206ef454a25417e3ba0bd3235c84518cb202c2d1fa7afcfdfcde5fdcde",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imissing": {
+    "status": "failed",
+    "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": "subtests.subtest.test_hdiff_imissing/result.png",
+    "baseline_hash": "afc411cfa34db3a5819ac4127704e86acf27d24d1ea2410718853d3d7e1d6ae0",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imatch": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hmissing_imatch/result.png",
+    "baseline_hash": "7ee8370efdc4b767634d12355657ca4f2460176670c07b31f3fb72cea0e79856",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_idiff": {
+    "status": "failed",
+    "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 12\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
+    "diff_image": "subtests.subtest.test_hmissing_idiff/result-failed-diff.png",
+    "rms": 12.12938597648977,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hmissing_idiff/result.png",
+    "baseline_hash": "4eeda1d349f4b0f26df97df41ba5410dce2b1c7ed520062d58f3c5f0e3790ebd",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imissing": {
+    "status": "failed",
+    "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "baseline_image": null,
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": "subtests.subtest.test_hmissing_imissing/result.png",
+    "baseline_hash": "5101e60ac100cf2c2f418a0a6a382aae0060339e76718730344f539b61f7dc7e",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_tolerance": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 200,
+    "result_image": "subtests.subtest.test_hdiff_imatch_tolerance/result.png",
+    "baseline_hash": "510b3273d63a2a26a27e788ff0f090e86c9df7f9f191b7c566321c57de8266d6",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff_tolerance": {
+    "status": "failed",
+    "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 29\\.2[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    3",
+    "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
+    "diff_image": "subtests.subtest.test_hdiff_idiff_tolerance/result-failed-diff.png",
+    "rms": 29.260332173249314,
+    "tolerance": 3,
+    "result_image": "subtests.subtest.test_hdiff_idiff_tolerance/result.png",
+    "baseline_hash": "510b3273d63a2a26a27e788ff0f090e86c9df7f9f191b7c566321c57de8266d6",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_savefig": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hdiff_imatch_savefig/result.png",
+    "baseline_hash": "8864803a4b4026d8c6dc0ab950228793ea255cd9b6c629c39db9e6315a9af6bc",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_style": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hdiff_imatch_style/result.png",
+    "baseline_hash": "e3c8de36c2bad7dca131e4cbbfe229f882b5beec62750fb7da29314fd6a1ff13",
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_removetext": {
+    "status": "passed",
+    "status_msg": "Image comparison passed.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": 2,
+    "result_image": "subtests.subtest.test_hdiff_imatch_removetext/result.png",
+    "baseline_hash": "e4c06cf613c6836c1b1202abaae69cf65bc2232a8e31ab1040454bedc8e31e7a",
+    "result_hash": null
+  }
+}

--- a/tests/subtests/summaries/test_html_generate_images_only.json
+++ b/tests/subtests/summaries/test_html_generate_images_only.json
@@ -1,0 +1,156 @@
+{
+  "subtests.subtest.test_hmatch_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmatch_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmatch_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmatch_imissing/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imissing/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imatch": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_idiff": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hmissing_imissing": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hmissing_imissing/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_tolerance": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_idiff_tolerance": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_savefig": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_style": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  },
+  "subtests.subtest.test_hdiff_imatch_removetext": {
+    "status": "skipped",
+    "status_msg": "Skipped test, since generating image.",
+    "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
+    "diff_image": null,
+    "rms": null,
+    "tolerance": null,
+    "result_image": null,
+    "baseline_hash": null,
+    "result_hash": null
+  }
+}

--- a/tests/subtests/summaries/test_html_generate_images_only.json
+++ b/tests/subtests/summaries/test_html_generate_images_only.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmatch_imatch/baseline.png",
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
     "diff_image": null,
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmatch_imissing/baseline.png",
     "diff_image": null,
@@ -34,6 +40,8 @@
   },
   "subtests.subtest.test_hdiff_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
     "diff_image": null,
@@ -45,6 +53,8 @@
   },
   "subtests.subtest.test_hdiff_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
     "diff_image": null,
@@ -56,6 +66,8 @@
   },
   "subtests.subtest.test_hdiff_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imissing/baseline.png",
     "diff_image": null,
@@ -67,6 +79,8 @@
   },
   "subtests.subtest.test_hmissing_imatch": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
     "diff_image": null,
@@ -78,6 +92,8 @@
   },
   "subtests.subtest.test_hmissing_idiff": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
     "diff_image": null,
@@ -89,6 +105,8 @@
   },
   "subtests.subtest.test_hmissing_imissing": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hmissing_imissing/baseline.png",
     "diff_image": null,
@@ -100,6 +118,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
     "diff_image": null,
@@ -111,6 +131,8 @@
   },
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
     "diff_image": null,
@@ -122,6 +144,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
     "diff_image": null,
@@ -133,6 +157,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
     "diff_image": null,
@@ -144,6 +170,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "skipped",
+    "image_status": "generated",
+    "hash_status": null,
     "status_msg": "Skipped test, since generating image.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
     "diff_image": null,

--- a/tests/subtests/summaries/test_html_hashes_only.json
+++ b/tests/subtests/summaries/test_html_hashes_only.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -35,6 +41,8 @@
   "subtests.subtest.test_hdiff_imatch": {
     "status": "failed",
     "status_msg": "REGEX:Hash 6e2fdde5a6682dc6abba7121f5df702c3664b1ce09593534fc0d7c3514eb07e1 doesn't match hash d1ffdde5a6682dc6abba7121f5df702c3664b1ce09593534fc0d7c3514eb07e1 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -46,6 +54,8 @@
   "subtests.subtest.test_hdiff_idiff": {
     "status": "failed",
     "status_msg": "REGEX:Hash 443361bdd0efd1cdd343eabf73af6f20439d4834ab5503a574ac7ec28e0c2b43 doesn't match hash d1ff61bdd0efd1cdd343eabf73af6f20439d4834ab5503a574ac7ec28e0c2b43 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_idiff\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -57,6 +67,8 @@
   "subtests.subtest.test_hdiff_imissing": {
     "status": "failed",
     "status_msg": "REGEX:Hash 301e63d656d7a586cc4e498bc32b970f8cb7c7c47bbd2fec33b931219fc0690e doesn't match hash d1ff63d656d7a586cc4e498bc32b970f8cb7c7c47bbd2fec33b931219fc0690e in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imissing\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -68,6 +80,8 @@
   "subtests.subtest.test_hmissing_imatch": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_imatch' not found in .*\\.json\\. Generated hash is eabd8a2e22afd88682990bfb8e4a0700a942fe68e5114e8da4ab6bd93c47b824\\.",
+    "image_status": null,
+    "hash_status": "missing",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -79,6 +93,8 @@
   "subtests.subtest.test_hmissing_idiff": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_idiff' not found in .*\\.json\\. Generated hash is e69570c4a70b2cc88ddee0f0a82312cae4f394b7f62e5760245feda1364c03ab\\.",
+    "image_status": null,
+    "hash_status": "missing",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -90,6 +106,8 @@
   "subtests.subtest.test_hmissing_imissing": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_imissing' not found in .*\\.json\\. Generated hash is 5c8a9c7412e4e098f6f2683ee247c08bd50805a93df4d4b6d8fccf3579b4c56b\\.",
+    "image_status": null,
+    "hash_status": "missing",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -101,6 +119,8 @@
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "failed",
     "status_msg": "REGEX:Hash aaf4e85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 doesn't match hash d1ffe85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_tolerance\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -112,6 +132,8 @@
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "failed",
     "status_msg": "REGEX:Hash aaf4e85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 doesn't match hash d1ffe85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_idiff_tolerance\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -123,6 +145,8 @@
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "failed",
     "status_msg": "REGEX:Hash 5dc1c2c68c2d34c03a89ab394e3c11349b76594d0c8837374daef299ac227568 doesn't match hash d1ffc2c68c2d34c03a89ab394e3c11349b76594d0c8837374daef299ac227568 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_savefig\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -134,6 +158,8 @@
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "failed",
     "status_msg": "REGEX:Hash 185ed1b702c7bbd810370b12e46ecea4b9c9eb87b743397f1d4a50177e7ba7f7 doesn't match hash d1ffd1b702c7bbd810370b12e46ecea4b9c9eb87b743397f1d4a50177e7ba7f7 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_style\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -145,6 +171,8 @@
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "failed",
     "status_msg": "REGEX:Hash be5af83a43cb89f5e13923f532fe5c9bedbf7d13585533efef2f4051c4968b5e doesn't match hash d1fff83a43cb89f5e13923f532fe5c9bedbf7d13585533efef2f4051c4968b5e in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_removetext\\.",
+    "image_status": null,
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,

--- a/tests/subtests/summaries/test_html_images_only.json
+++ b/tests/subtests/summaries/test_html_images_only.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hmatch_imatch/baseline.png",
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": null,
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmatch_idiff/result-failed-diff.png",
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": null,
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -34,6 +40,8 @@
   },
   "subtests.subtest.test_hdiff_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
     "diff_image": null,
@@ -45,6 +53,8 @@
   },
   "subtests.subtest.test_hdiff_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": null,
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff/result-failed-diff.png",
@@ -56,6 +66,8 @@
   },
   "subtests.subtest.test_hdiff_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": null,
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -67,6 +79,8 @@
   },
   "subtests.subtest.test_hmissing_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
     "diff_image": null,
@@ -78,6 +92,8 @@
   },
   "subtests.subtest.test_hmissing_idiff": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": null,
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 12\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmissing_idiff/result-failed-diff.png",
@@ -89,6 +105,8 @@
   },
   "subtests.subtest.test_hmissing_imissing": {
     "status": "failed",
+    "image_status": "missing",
+    "hash_status": null,
     "status_msg": "REGEX:Image file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -100,6 +118,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
     "diff_image": null,
@@ -111,6 +131,8 @@
   },
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "failed",
+    "image_status": "diff",
+    "hash_status": null,
     "status_msg": "REGEX:Error: Image files did not match\\.\n  RMS Value: 29\\.2[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    3",
     "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff_tolerance/result-failed-diff.png",
@@ -122,6 +144,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
     "diff_image": null,
@@ -133,6 +157,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
     "diff_image": null,
@@ -144,6 +170,8 @@
   },
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": null,
     "status_msg": "Image comparison passed.",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
     "diff_image": null,

--- a/tests/subtests/summaries/test_hybrid.json
+++ b/tests/subtests/summaries/test_hybrid.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "passed",
+    "image_status": null,
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.",
     "baseline_image": null,
     "diff_image": null,
@@ -35,6 +41,8 @@
   "subtests.subtest.test_hdiff_imatch": {
     "status": "failed",
     "status_msg": "REGEX:Hash 6e2fdde5a6682dc6abba7121f5df702c3664b1ce09593534fc0d7c3514eb07e1 doesn't match hash d1ffdde5a6682dc6abba7121f5df702c3664b1ce09593534fc0d7c3514eb07e1 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -46,6 +54,8 @@
   "subtests.subtest.test_hdiff_idiff": {
     "status": "failed",
     "status_msg": "REGEX:Hash 443361bdd0efd1cdd343eabf73af6f20439d4834ab5503a574ac7ec28e0c2b43 doesn't match hash d1ff61bdd0efd1cdd343eabf73af6f20439d4834ab5503a574ac7ec28e0c2b43 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_idiff\\.\n\nImage comparison test\n---------------------\nError: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "image_status": "diff",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff/result-failed-diff.png",
     "rms": 11.182677079602481,
@@ -57,6 +67,8 @@
   "subtests.subtest.test_hdiff_imissing": {
     "status": "failed",
     "status_msg": "REGEX:Hash 301e63d656d7a586cc4e498bc32b970f8cb7c7c47bbd2fec33b931219fc0690e doesn't match hash d1ff63d656d7a586cc4e498bc32b970f8cb7c7c47bbd2fec33b931219fc0690e in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imissing\\.\n\nImage comparison test\n---------------------\nImage file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "image_status": "missing",
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -68,6 +80,8 @@
   "subtests.subtest.test_hmissing_imatch": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_imatch' not found in .*\\.json\\. Generated hash is eabd8a2e22afd88682990bfb8e4a0700a942fe68e5114e8da4ab6bd93c47b824\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "missing",
     "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -79,6 +93,8 @@
   "subtests.subtest.test_hmissing_idiff": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_idiff' not found in .*\\.json\\. Generated hash is e69570c4a70b2cc88ddee0f0a82312cae4f394b7f62e5760245feda1364c03ab\\.\n\nImage comparison test\n---------------------\nError: Image files did not match\\.\n  RMS Value: 12\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "image_status": "diff",
+    "hash_status": "missing",
     "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmissing_idiff/result-failed-diff.png",
     "rms": 12.12938597648977,
@@ -90,6 +106,8 @@
   "subtests.subtest.test_hmissing_imissing": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_imissing' not found in .*\\.json\\. Generated hash is 5c8a9c7412e4e098f6f2683ee247c08bd50805a93df4d4b6d8fccf3579b4c56b\\.\n\nImage comparison test\n---------------------\nImage file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "image_status": "missing",
+    "hash_status": "missing",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -101,6 +119,8 @@
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "failed",
     "status_msg": "REGEX:Hash aaf4e85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 doesn't match hash d1ffe85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_tolerance\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -112,6 +132,8 @@
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "failed",
     "status_msg": "REGEX:Hash aaf4e85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 doesn't match hash d1ffe85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_idiff_tolerance\\.\n\nImage comparison test\n---------------------\nError: Image files did not match\\.\n  RMS Value: 29\\.2[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    3",
+    "image_status": "diff",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff_tolerance/result-failed-diff.png",
     "rms": 29.260332173249314,
@@ -123,6 +145,8 @@
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "failed",
     "status_msg": "REGEX:Hash 5dc1c2c68c2d34c03a89ab394e3c11349b76594d0c8837374daef299ac227568 doesn't match hash d1ffc2c68c2d34c03a89ab394e3c11349b76594d0c8837374daef299ac227568 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_savefig\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -134,6 +158,8 @@
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "failed",
     "status_msg": "REGEX:Hash 185ed1b702c7bbd810370b12e46ecea4b9c9eb87b743397f1d4a50177e7ba7f7 doesn't match hash d1ffd1b702c7bbd810370b12e46ecea4b9c9eb87b743397f1d4a50177e7ba7f7 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_style\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -145,6 +171,8 @@
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "failed",
     "status_msg": "REGEX:Hash be5af83a43cb89f5e13923f532fe5c9bedbf7d13585533efef2f4051c4968b5e doesn't match hash d1fff83a43cb89f5e13923f532fe5c9bedbf7d13585533efef2f4051c4968b5e in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_removetext\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
     "diff_image": null,
     "rms": null,

--- a/tests/subtests/summaries/test_results_always.json
+++ b/tests/subtests/summaries/test_results_always.json
@@ -1,6 +1,8 @@
 {
   "subtests.subtest.test_hmatch_imatch": {
     "status": "passed",
+    "image_status": "match",
+    "hash_status": "match",
     "status_msg": "Test hash matches baseline hash.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded.",
     "baseline_image": "subtests.subtest.test_hmatch_imatch/baseline.png",
     "diff_image": null,
@@ -12,6 +14,8 @@
   },
   "subtests.subtest.test_hmatch_idiff": {
     "status": "passed",
+    "image_status": "diff",
+    "hash_status": "match",
     "status_msg": "REGEX:Test hash matches baseline hash\\.\n\nImage comparison test\n---------------------\nError: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
     "baseline_image": "subtests.subtest.test_hmatch_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmatch_idiff/result-failed-diff.png",
@@ -23,6 +27,8 @@
   },
   "subtests.subtest.test_hmatch_imissing": {
     "status": "passed",
+    "image_status": "missing",
+    "hash_status": "match",
     "status_msg": "REGEX:Test hash matches baseline hash\\.\n\nImage comparison test\n---------------------\nImage file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
     "baseline_image": null,
     "diff_image": null,
@@ -35,6 +41,8 @@
   "subtests.subtest.test_hdiff_imatch": {
     "status": "failed",
     "status_msg": "REGEX:Hash 6e2fdde5a6682dc6abba7121f5df702c3664b1ce09593534fc0d7c3514eb07e1 doesn't match hash d1ffdde5a6682dc6abba7121f5df702c3664b1ce09593534fc0d7c3514eb07e1 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -46,6 +54,8 @@
   "subtests.subtest.test_hdiff_idiff": {
     "status": "failed",
     "status_msg": "REGEX:Hash 443361bdd0efd1cdd343eabf73af6f20439d4834ab5503a574ac7ec28e0c2b43 doesn't match hash d1ff61bdd0efd1cdd343eabf73af6f20439d4834ab5503a574ac7ec28e0c2b43 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_idiff\\.\n\nImage comparison test\n---------------------\nError: Image files did not match\\.\n  RMS Value: 11\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "image_status": "diff",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff/result-failed-diff.png",
     "rms": 11.182677079602481,
@@ -57,6 +67,8 @@
   "subtests.subtest.test_hdiff_imissing": {
     "status": "failed",
     "status_msg": "REGEX:Hash 301e63d656d7a586cc4e498bc32b970f8cb7c7c47bbd2fec33b931219fc0690e doesn't match hash d1ff63d656d7a586cc4e498bc32b970f8cb7c7c47bbd2fec33b931219fc0690e in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imissing\\.\n\nImage comparison test\n---------------------\nImage file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "image_status": "missing",
+    "hash_status": "diff",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -68,6 +80,8 @@
   "subtests.subtest.test_hmissing_imatch": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_imatch' not found in .*\\.json\\. Generated hash is eabd8a2e22afd88682990bfb8e4a0700a942fe68e5114e8da4ab6bd93c47b824\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "missing",
     "baseline_image": "subtests.subtest.test_hmissing_imatch/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -79,6 +93,8 @@
   "subtests.subtest.test_hmissing_idiff": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_idiff' not found in .*\\.json\\. Generated hash is e69570c4a70b2cc88ddee0f0a82312cae4f394b7f62e5760245feda1364c03ab\\.\n\nImage comparison test\n---------------------\nError: Image files did not match\\.\n  RMS Value: 12\\.1[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    2",
+    "image_status": "diff",
+    "hash_status": "missing",
     "baseline_image": "subtests.subtest.test_hmissing_idiff/baseline.png",
     "diff_image": "subtests.subtest.test_hmissing_idiff/result-failed-diff.png",
     "rms": 12.12938597648977,
@@ -90,6 +106,8 @@
   "subtests.subtest.test_hmissing_imissing": {
     "status": "failed",
     "status_msg": "REGEX:Hash for test 'subtests\\.subtest\\.test_hmissing_imissing' not found in .*\\.json\\. Generated hash is 5c8a9c7412e4e098f6f2683ee247c08bd50805a93df4d4b6d8fccf3579b4c56b\\.\n\nImage comparison test\n---------------------\nImage file not found for comparison test in: \n\t.*\n\\(This is expected for new tests\\.\\)\nGenerated Image: \n\t.*result\\.png",
+    "image_status": "missing",
+    "hash_status": "missing",
     "baseline_image": null,
     "diff_image": null,
     "rms": null,
@@ -101,6 +119,8 @@
   "subtests.subtest.test_hdiff_imatch_tolerance": {
     "status": "failed",
     "status_msg": "REGEX:Hash aaf4e85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 doesn't match hash d1ffe85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_tolerance\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_tolerance/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -112,6 +132,8 @@
   "subtests.subtest.test_hdiff_idiff_tolerance": {
     "status": "failed",
     "status_msg": "REGEX:Hash aaf4e85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 doesn't match hash d1ffe85fda98298347c274adae98ca7728f9bb2444ca8a49295145b0727b8c96 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_idiff_tolerance\\.\n\nImage comparison test\n---------------------\nError: Image files did not match\\.\n  RMS Value: 29\\.2[0-9]*\n  Expected:  \n    .*baseline\\.png\n  Actual:    \n    .*result\\.png\n  Difference:\n    .*result-failed-diff\\.png\n  Tolerance: \n    3",
+    "image_status": "diff",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_idiff_tolerance/baseline.png",
     "diff_image": "subtests.subtest.test_hdiff_idiff_tolerance/result-failed-diff.png",
     "rms": 29.260332173249314,
@@ -123,6 +145,8 @@
   "subtests.subtest.test_hdiff_imatch_savefig": {
     "status": "failed",
     "status_msg": "REGEX:Hash 5dc1c2c68c2d34c03a89ab394e3c11349b76594d0c8837374daef299ac227568 doesn't match hash d1ffc2c68c2d34c03a89ab394e3c11349b76594d0c8837374daef299ac227568 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_savefig\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_savefig/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -134,6 +158,8 @@
   "subtests.subtest.test_hdiff_imatch_style": {
     "status": "failed",
     "status_msg": "REGEX:Hash 185ed1b702c7bbd810370b12e46ecea4b9c9eb87b743397f1d4a50177e7ba7f7 doesn't match hash d1ffd1b702c7bbd810370b12e46ecea4b9c9eb87b743397f1d4a50177e7ba7f7 in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_style\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_style/baseline.png",
     "diff_image": null,
     "rms": null,
@@ -145,6 +171,8 @@
   "subtests.subtest.test_hdiff_imatch_removetext": {
     "status": "failed",
     "status_msg": "REGEX:Hash be5af83a43cb89f5e13923f532fe5c9bedbf7d13585533efef2f4051c4968b5e doesn't match hash d1fff83a43cb89f5e13923f532fe5c9bedbf7d13585533efef2f4051c4968b5e in library .*\\.json for test subtests\\.subtest\\.test_hdiff_imatch_removetext\\.\n\nImage comparison test\n---------------------\nThe comparison to the baseline image succeeded\\.",
+    "image_status": "match",
+    "hash_status": "diff",
     "baseline_image": "subtests.subtest.test_hdiff_imatch_removetext/baseline.png",
     "diff_image": null,
     "rms": null,


### PR DESCRIPTION
Main task was creating the hash library file in the results directory and making it available to download in the sort/filter menu in the HTML summary. Fixed various other things:

### HTML summary when generating
When generating baseline images, the generated images now appear in a requested HTML summary. (See the "Generating baseline images..." demos: https://macbride.me/pytest-mpl/.)

### Documented behaviour when generating hashes
Documented the existing behaviour: when generating a hash library, the tests will also be run as usual against the existing hash library specified by ``--mpl-hash-library`` or the keyword argument. However, generating baseline images will always result in the tests being skipped.

### Make an updated hash library downloadable from HTML summary
When the ``--mpl-results-always`` option is active, and some hash comparison tests are performed, a hash library containing all the result hashes will also be saved to the root of the results directory. The filename will be extracted from ``--mpl-generate-hash-library``, ``--mpl-hash-library`` or ``hash_library=`` in that order.

Made the generated hash library available to download in the sort/filter menu of the HTML summary. (See any demo involving hash generation or comparison: https://macbride.me/pytest-mpl/.)

Closes #135 

### Removed incorrect warning
Removed warning ``Ignoring --mpl-result-path since --mpl-generate-path is set`` because when generating, a HTML summary may be saved there.

### Added tests for the generating options
These test that the JSON summaries match for various combinations of hashes and/or images generating options. Generated hash libraries are verified against the baseline. (Although, generated images are not currently verified.) Any generated HTML summaries are available here: https://macbride.me/pytest-mpl/

### Additional commits on 2022-02-19
- Added `image_status` and `hash_status` to the JSON report so it's easier to determine the individual results in the HTML report. Statuses are `match`, `diff`, `missing`, `generated` and `None`.
- Improved how the HTML template only shows relevant information based on the result of each test.
- Updated the demos linked above to include the new commits.