### PR TITLE
No need to warn when falling back to other URL

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -62,7 +62,7 @@ def _download_file(baseline, filename):
             u = urlopen(base_url + filename)
             content = u.read()
         except Exception as e:
-            warnings.warn('Downloading {0} failed: {1}'.format(base_url + filename, e))
+            pass
         else:
             break
     else:

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -358,7 +358,7 @@ class ImageComparison:
                 u = urlopen(base_url + filename)
                 content = u.read()
             except Exception as e:
-                self.logger.debug(f'Downloading {base_url + filename} failed: {repr(e)}')
+                self.logger.info(f'Downloading {base_url + filename} failed: {repr(e)}')
             else:
                 break
         else:


### PR DESCRIPTION
It causes unnecessary failure when test suite is set up to turn all unhandled warnings to exceptions.

cc @dhomeier