### PR TITLE
ENH: make summary log message about test results in general instead of failures

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -726,11 +726,11 @@ class ImageComparison:
                 kwargs["hash_library"] = result_hash_library.name
             if 'html' in self.generate_summary:
                 summary = generate_summary_html(self._test_results, self.results_dir, **kwargs)
-                print(f"A summary of the failed tests can be found at: {summary}")
+                print(f"A summary of test results can be found at: {summary}")
             if 'basic-html' in self.generate_summary:
                 summary = generate_summary_basic_html(self._test_results, self.results_dir,
                                                       **kwargs)
-                print(f"A summary of the failed tests can be found at: {summary}")
+                print(f"A summary of test results can be found at: {summary}")
 
 
 class FigureCloser:

--- a/tests/test_pytest_mpl.py
+++ b/tests/test_pytest_mpl.py
@@ -297,7 +297,7 @@ def test_hash_fails(tmpdir):
     output = assert_pytest_fails_with(['--mpl', test_file, '--mpl-generate-summary=html'],
                                       "doesn't match hash FAIL in library")
     # We didn't specify a baseline dir so we shouldn't attempt to find one
-    print_message = "A summary of the failed tests can be found at:"
+    print_message = "A summary of test results can be found at:"
     assert print_message in output, output
     printed_path = Path(output.split(print_message)[1].strip())
     assert printed_path.exists()


### PR DESCRIPTION
I've noticed that the message that gets printed when using `--mpl-generate-summary=html` is _always_ refering to "failed tests" even if all tests passed.
This should fix that.
