### PR TITLE
Pin tox environment `mpl35` to matplotlib 3.5.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     mpl32: matplotlib==3.2.*
     mpl33: matplotlib==3.3.*
     mpl34: matplotlib==3.4.*
-    mpl35: matplotlib==3.5.*
+    mpl35: matplotlib==3.5.1
     mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
 extras =
     test


### PR DESCRIPTION
This pins the `mpl35` tox environment to matplotlib 3.5.1. The new version has changed many of the hashes, possibly due to the version number being included in the PNG metadata of the existing hashed files. I'll remove this metadata and regenerate hashes for the latest version of matplotlib when sorting #159.