### PR TITLE
Add support for classes with pytest 7

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -33,6 +33,10 @@ jobs:
         - linux: py38-test-mpl33
         - linux: py39-test-mpl34
         - linux: py310-test-mpl35
+        # Test different versions of pytest
+        - linux: py310-test-mpl35-pytestdev
+        - linux: py310-test-mpl35-pytest62
+        - linux: py310-test-mpl35-pytest54
       coverage: 'codecov'
 
   publish:

--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -36,7 +36,7 @@ jobs:
         # Test different versions of pytest
         - linux: py310-test-mpl35-pytestdev
         - linux: py310-test-mpl35-pytest62
-        - linux: py310-test-mpl35-pytest54
+        - linux: py38-test-mpl35-pytest54
       coverage: 'codecov'
 
   publish:

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -302,7 +302,11 @@ class ImageComparison:
         """
         Generate a unique name for the hash for this test.
         """
-        return f"{item.module.__name__}.{item.name}"
+        if item.cls is not None:
+            name = f"{item.module.__name__}.{item.cls.__name__}.{item.name}"
+        else:
+            name = f"{item.module.__name__}.{item.name}"
+        return name
 
     def make_test_results_dir(self, item):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,13 @@ deps =
     mpl34: matplotlib==3.4.*
     mpl35: matplotlib==3.5.1
     mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
+    pytest54: pytest==5.4.*
+    pytest60: pytest==6.0.*
+    pytest61: pytest==6.1.*
+    pytest62: pytest==6.2.*
+    pytest70: pytest==7.0.*
+    pytest71: pytest==7.1.*
+    pytestdev: git+https://github.com/pytest-dev/pytest.git#egg=pytest
 extras =
     test
 commands =


### PR DESCRIPTION
Since `pytest` 7 was released `pytest-mpl` has not been running tests inside classes. This means that figure tests inside classes are always being reported as passing. In this PR, I have added additional tests that ensure figure tests inside classes can fail correctly, and I have also added new testing jobs for older versions of pytest as well as the development version.

- [x] Find the bug and fix it
- [ ] Make a bugfix release of `pytest-mpl`

### Solution

Instead modifying the test function itself by wrapping it in a function which runs the tests, this PR uses pytest hooks to intercept the generated figure and then run the tests. This should be a more robust approach that doesn't need as many special cases to be hardcoded (such as classes and support for `setup_method` etc.).

Previously we updated the test function (to a version of itself but wrapped in the testing code) inside the `pytest_runtest_setup` hook. However, now we work inside the `pytest_runtest_call` hook and [override pytest's default `pytest_pyfunc_call` hook](https://github.com/pytest-dev/pytest/blob/c2f684fcd6af2818a5ddeb99cd5b8367a91e99ef/src/_pytest/python.py#L187-L204):

1. A test starts
2. Pytest calls our `pytest_runtest_call` hook
3. It runs until `yield`
4. Pytest then calls our `pytest_pyfunc_call` hook which runs the test function, intercepts the returned figure, and saves it as an attribute (`self.result`)
5. Pytest then continues after the `yield` inside our `pytest_runtest_call` hook
6. It accesses the figure from the attribute `self.result`
7. It tests the figure

I have also combined the `get_marker` and `get_compare` functions/methods to simplify these.