### PR TITLE
Improve parametrized test names in HTML summaries

### DIFF
--- a/pytest_mpl/summary/html.py
+++ b/pytest_mpl/summary/html.py
@@ -93,8 +93,9 @@ class Result:
 
         # Name of test with module and test function together and separate
         self.full_name = name
-        self.name = name.split('.')[-1]
-        self.module = '.'.join(name.split('.')[:-1])
+        without_parametrized_name = name.split("[")[0]
+        self.module = ".".join(without_parametrized_name.split(".")[:-1])
+        self.name = name[len(self.module)+1:]
 
         # Additional classes to add to the result card
         self.classes = [f'{k}-{str(v).lower()}' for k, v in [

--- a/pytest_mpl/summary/templates/basic.html
+++ b/pytest_mpl/summary/templates/basic.html
@@ -73,7 +73,7 @@
             {%- endif %}
         </td>
         {% macro image(file) -%}
-        <td>{% if file %}<img src="{{ file }}">{% endif %}</td>
+        <td>{% if file %}<img src="{{ file | urlencode }}">{% endif %}</td>
         {%- endmacro -%}
         {{ image(result.baseline_image) }}
         {{ image(result.diff_image) }}

--- a/pytest_mpl/summary/templates/result.html
+++ b/pytest_mpl/summary/templates/result.html
@@ -12,19 +12,19 @@
             <div class="hover-image">
                 {% if r.diff_image -%}
                 <div class="diff-image">
-                    <img src="{{ r.diff_image }}" class="card-img-top" alt="diff image">
+                    <img src="{{ r.diff_image | urlencode }}" class="card-img-top" alt="diff image">
                 </div>
                 <div class="result-image">
-                    <img src="{{ r.result_image }}" class="card-img-top" alt="result image">
+                    <img src="{{ r.result_image | urlencode }}" class="card-img-top" alt="result image">
                 </div>
                 {%- else -%}
-                <img src="{{ r.result_image }}" class="card-img-top" alt="result image">
+                <img src="{{ r.result_image | urlencode }}" class="card-img-top" alt="result image">
                 {%- endif %}
             </div>
             {%- elif r.result_image -%}
-            <img src="{{ r.result_image }}" class="card-img-top" alt="result image">
+            <img src="{{ r.result_image | urlencode }}" class="card-img-top" alt="result image">
             {%- elif r.baseline_image -%}
-            <img src="{{ r.baseline_image }}" class="card-img-top" alt="baseline image">
+            <img src="{{ r.baseline_image | urlencode }}" class="card-img-top" alt="baseline image">
             {%- endif %}
         </a>
         {% filter indent(width=8) -%}

--- a/pytest_mpl/summary/templates/result_images.html
+++ b/pytest_mpl/summary/templates/result_images.html
@@ -13,7 +13,7 @@
                 <div class="card h-100">
                     <div class="card-header">{{ name }}</div>
                     {% if file -%}
-                    <img src="{{ file }}" class="card-img-top" alt="{{ name }}">
+                    <img src="{{ file | urlencode }}" class="card-img-top" alt="{{ name }}">
                     {%- endif %}
                 </div>
             </div>


### PR DESCRIPTION
This is a bugfix PR which only affects the HTML summaries. The following bugs are fixed:

- **Fix bug with splitting parametrized test name**
  "a.b.test_c[x.y]" should give ("a.b", "test_c[x.y]") and not ("a.b.test_c[x", "y]")

- **urlencode image URLs**
  The images are path safe but not URL safe. Parametrized tests can include characters such as "\" or "?" in their name which can lead to 404 errors in the HTML summary report.