### PR TITLE
Fix tests which exit before returning a figure or use `unittest.TestCase`

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -622,6 +622,9 @@ class ImageComparison:
             wrap_figure_interceptor(self, item)
             yield
             test_name = generate_test_name(item)
+            if test_name not in self.return_value:
+                # Test function did not complete successfully
+                return
             fig = self.return_value[test_name]
 
             if remove_text:
@@ -749,5 +752,8 @@ class FigureCloser:
         yield
         if get_compare(item) is not None:
             test_name = generate_test_name(item)
+            if test_name not in self.return_value:
+                # Test function did not complete successfully
+                return
             fig = self.return_value[test_name]
             close_mpl_figure(fig)

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -89,6 +89,17 @@ def _pytest_pyfunc_call(obj, pyfuncitem):
     return True
 
 
+def generate_test_name(item):
+    """
+    Generate a unique name for the hash for this test.
+    """
+    if item.cls is not None:
+        name = f"{item.module.__name__}.{item.cls.__name__}.{item.name}"
+    else:
+        name = f"{item.module.__name__}.{item.name}"
+    return name
+
+
 def pytest_report_header(config, startdir):
     import matplotlib
     import matplotlib.ft2font
@@ -287,7 +298,7 @@ class ImageComparison:
         Given a pytest item, generate the figure filename.
         """
         if self.config.getini('mpl-use-full-test-name'):
-            filename = self.generate_test_name(item) + '.png'
+            filename = generate_test_name(item) + '.png'
         else:
             compare = get_compare(item)
             # Find test name to use as plot name
@@ -298,21 +309,11 @@ class ImageComparison:
         filename = str(pathify(filename))
         return filename
 
-    def generate_test_name(self, item):
-        """
-        Generate a unique name for the hash for this test.
-        """
-        if item.cls is not None:
-            name = f"{item.module.__name__}.{item.cls.__name__}.{item.name}"
-        else:
-            name = f"{item.module.__name__}.{item.name}"
-        return name
-
     def make_test_results_dir(self, item):
         """
         Generate the directory to put the results in.
         """
-        test_name = pathify(self.generate_test_name(item))
+        test_name = pathify(generate_test_name(item))
         results_dir = self.results_dir / test_name
         results_dir.mkdir(exist_ok=True, parents=True)
         return results_dir
@@ -526,7 +527,7 @@ class ImageComparison:
             pytest.fail(f"Can't find hash library at path {hash_library_filename}")
 
         hash_library = self.load_hash_library(hash_library_filename)
-        hash_name = self.generate_test_name(item)
+        hash_name = generate_test_name(item)
         baseline_hash = hash_library.get(hash_name, None)
         summary['baseline_hash'] = baseline_hash
 
@@ -613,7 +614,7 @@ class ImageComparison:
             if remove_text:
                 remove_ticks_and_titles(fig)
 
-            test_name = self.generate_test_name(item)
+            test_name = generate_test_name(item)
             result_dir = self.make_test_results_dir(item)
 
             summary = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,8 @@ markers =
     hash: run test during hash comparison only mode.
 filterwarnings =
     error
+    ignore:distutils Version classes are deprecated
+    ignore:the imp module is deprecated in favour of importlib
 
 [flake8]
 max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,11 @@ test =
 
 [tool:pytest]
 testpaths = "tests"
+markers =
+    image: run test during image comparison only mode.
+    hash: run test during hash comparison only mode.
+filterwarnings =
+    error
 
 [flake8]
 max-line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from packaging.version import Version
+
+pytest_plugins = ["pytester"]
+
+if Version(pytest.__version__) < Version("6.2.0"):
+    @pytest.fixture
+    def pytester(testdir):
+        return testdir

--- a/tests/test_pytest_mpl.py
+++ b/tests/test_pytest_mpl.py
@@ -566,3 +566,107 @@ def test_class_fail(code, tmpdir):
     # If we don't use --mpl option, the test should succeed
     code = call_pytest([test_file])
     assert code == 0
+
+
+@pytest.mark.parametrize("runpytest_args", [(), ("--mpl",)])
+def test_user_fail(pytester, runpytest_args):
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.mpl_image_compare
+        def test_fail():
+            pytest.fail("Manually failed by user.")
+    """
+    )
+    result = pytester.runpytest(*runpytest_args)
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines("FAILED*Manually failed by user.*")
+
+
+@pytest.mark.parametrize("runpytest_args", [(), ("--mpl",)])
+def test_user_skip(pytester, runpytest_args):
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.mpl_image_compare
+        def test_skip():
+            pytest.skip("Manually skipped by user.")
+    """
+    )
+    result = pytester.runpytest(*runpytest_args)
+    result.assert_outcomes(skipped=1)
+
+
+@pytest.mark.parametrize("runpytest_args", [(), ("--mpl",)])
+def test_user_importorskip(pytester, runpytest_args):
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.mpl_image_compare
+        def test_importorskip():
+            pytest.importorskip("nonexistantmodule")
+    """
+    )
+    result = pytester.runpytest(*runpytest_args)
+    result.assert_outcomes(skipped=1)
+
+
+@pytest.mark.parametrize("runpytest_args", [(), ("--mpl",)])
+def test_user_xfail(pytester, runpytest_args):
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.mpl_image_compare
+        def test_xfail():
+            pytest.xfail()
+    """
+    )
+    result = pytester.runpytest(*runpytest_args)
+    result.assert_outcomes(xfailed=1)
+
+
+@pytest.mark.parametrize("runpytest_args", [(), ("--mpl",)])
+def test_user_exit_success(pytester, runpytest_args):
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.mpl_image_compare
+        def test_exit_success():
+            pytest.exit("Manually exited by user.", returncode=0)
+    """
+    )
+    result = pytester.runpytest(*runpytest_args)
+    result.assert_outcomes()
+    assert result.ret == 0
+    result.stdout.fnmatch_lines("*Exit*Manually exited by user.*")
+
+
+@pytest.mark.parametrize("runpytest_args", [(), ("--mpl",)])
+def test_user_exit_failure(pytester, runpytest_args):
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.mpl_image_compare
+        def test_exit_fail():
+            pytest.exit("Manually exited by user.", returncode=1)
+    """
+    )
+    result = pytester.runpytest(*runpytest_args)
+    result.assert_outcomes()
+    assert result.ret == 1
+    result.stdout.fnmatch_lines("*Exit*Manually exited by user.*")
+
+
+@pytest.mark.parametrize("runpytest_args", [(), ("--mpl",)])
+def test_user_function_raises(pytester, runpytest_args):
+    pytester.makepyfile(
+        """
+        import pytest
+        @pytest.mark.mpl_image_compare
+        def test_raises():
+            raise ValueError("User code raised an exception.")
+    """
+    )
+    result = pytester.runpytest(*runpytest_args)
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines("FAILED*ValueError*User code*")

--- a/tox.ini
+++ b/tox.ini
@@ -51,8 +51,3 @@ description = check code style, e.g. with flake8
 deps = pre-commit
 commands =
     pre-commit run --all-files
-
-[pytest]
-markers =
-    image: run test during image comparison only mode.
-    hash: run test during hash comparison only mode.


### PR DESCRIPTION
Fixes #170

Currently pytest-mpl relies on the `pytest_pyfunc_call` hook to intercept the figure for testing from the test function. However, when using `unittest.TestCase` this hook is not used. Rather than adding a specific fix for `unittest.TestCase`, in this PR I have refactored pytest-mpl such that, instead of using the `pytest_pyfunc_call` hook, within the `pytest_runtest_call` hook pytest-mpl will,

1. wrap the user's test function in a wrapper which stores the returned figure in the plugin, and makes the user's test function return `None` instead, (pytest will require `None` to be returned in a future version.)
2. `yield` to pytest so pytest can call the test function (either with its `pytest_pyfunc_call`, or otherwise in the case of `unittest.TestCase`),
3. retrieve the returned figure from the plugin object (i.e. `self`),
4. carry on as usual with the testing of the returned figure.

I've added tests to ensure pytest-mpl can both pass and fail as expected when testing using `unittest.TestCase`.

Just to be sure pytest-mpl now works with a variety of different testing setups, before we make a bugfix release I want to add tests to `tests/subtests` for testing classes. I'll do that in a separate PR.