### PR TITLE
Update path to Jinja2 templates

### DIFF
--- a/pytest_mpl/summary/html.py
+++ b/pytest_mpl/summary/html.py
@@ -214,7 +214,7 @@ def generate_summary_html(results, results_dir, hash_library=None):
 
     # Initialize Jinja
     env = Environment(
-        loader=PackageLoader("pytest_mpl.summary.html"),
+        loader=PackageLoader("pytest_mpl.summary", "templates"),
         autoescape=select_autoescape()
     )
 
@@ -254,7 +254,7 @@ def generate_summary_basic_html(results, results_dir, hash_library=None):
 
     # Initialize Jinja
     env = Environment(
-        loader=PackageLoader("pytest_mpl.summary.html"),
+        loader=PackageLoader("pytest_mpl.summary", "templates"),
         autoescape=select_autoescape()
     )
 


### PR DESCRIPTION
A test from #179 was showing:
```
ValueError: The 'pytest_mpl.summary.html' package was not installed in a way that PackageLoader understands.
```

The update in this PR might fix that as it follows the [PackageLoader docs](https://pydoc.dev/jinja2/latest/jinja2.loaders.PackageLoader.html), although we should check why it usually works with `pytest_mpl.summary.html`.