### PR TITLE
Upgrade for tox 4

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -25,8 +25,11 @@ jobs:
         - windows: py310-test-mpl36
         # Test all configurations on Linux
         - linux: py36-test-mpl20
+          runs-on: ubuntu-20.04
         - linux: py36-test-mpl21
+          runs-on: ubuntu-20.04
         - linux: py36-test-mpl22
+          runs-on: ubuntu-20.04
         - linux: py37-test-mpl30
         - linux: py37-test-mpl31
         - linux: py37-test-mpl32

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,10 @@ requires =
 isolated_build = true
 
 [testenv]
-passenv = DISPLAY WINDIR MPL_UPDATE_*
+passenv =
+    DISPLAY
+    WINDIR
+    MPL_UPDATE_*
 setenv =
     MPLBACKEND = Agg
 changedir = .tmp/{envname}


### PR DESCRIPTION
- Updated syntax of `tox.ini`
- When testing py36 on linux, need to downgrade the Ubuntu version. (We should probably just end support for py36, but wait until it breaks?)