### PR TITLE
Improve error reporting when test raises an exception

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -407,7 +407,7 @@ class ImageComparison:
             tmpfile.write(content)
         return Path(filename)
 
-    def obtain_baseline_image(self, item, target_dir):
+    def obtain_baseline_image(self, item):
         """
         Copy the baseline image to our working directory.
 
@@ -471,7 +471,7 @@ class ImageComparison:
 
         ext = self._file_extension(item)
 
-        baseline_image_ref = self.obtain_baseline_image(item, result_dir)
+        baseline_image_ref = self.obtain_baseline_image(item)
 
         test_image = (result_dir / f"result.{ext}").absolute()
         self.save_figure(item, fig, test_image)


### PR DESCRIPTION
When a test function raises an exception or does not return a figure, the failure is not reported in the HTML summary. This PR makes a fallback result be logged before calling the test function, so it will appear in the HTML summary in case an exception is raised.

This PR also fixes a bug where, when in hybrid mode, a missing baseline image from a remote URL was not being recorded in the status report. This change makes the code process a baseline download failure similar to how it processes a missing local baseline file.