### PR TITLE
Allow using `-p no:legacypath` with `pytest` >= 7

### DIFF
--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from urllib.request import urlopen
 
 import pytest
+from packaging.version import Version
 
 from pytest_mpl.summary.html import generate_summary_basic_html, generate_summary_html
 
@@ -56,6 +57,8 @@ SHAPE_MISMATCH_ERROR = """Error: Image dimensions did not match.
   Actual shape: {actual_shape}
     {actual_path}"""
 
+PYTEST_LT_7 = Version(pytest.__version__) < Version("7.0.0")
+
 # The following are the subsets of formats supported by the Matplotlib image
 # comparison machinery
 RASTER_IMAGE_FORMATS = ['png']
@@ -64,8 +67,8 @@ ALL_IMAGE_FORMATS = RASTER_IMAGE_FORMATS + VECTOR_IMAGE_FORMATS
 
 
 def _get_item_dir(item):
-    # .path is available starting from pytest 7, .fspath is for older versions.
-    return getattr(item, "path", Path(item.fspath)).parent
+    path = Path(item.fspath) if PYTEST_LT_7 else item.path
+    return path.parent
 
 
 def _hash_file(in_stream):


### PR DESCRIPTION
[The `-p no:legacypath` option for `pytest` prevents using legacy `py.path` and forces using `pathlib` from the Python standard library instead.](https://docs.pytest.org/en/stable/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures) 07e12f4fe360493899c53c172a8d1a02cfdd0d21 attempted to remove all uses of `py.path` with `pytest` >= 7 so that downstream packages could use that option, (at least with recent enough `pytest`). That commit introduced using [`getattr()`](https://docs.python.org/3/library/functions.html#getattr) to access the `path` attribute of [`_pytest.nodes.Node`](https://docs.pytest.org/en/stable/reference/reference.html#pytest.nodes.Node) instances and falling back to the `fspath` attribute if `path` does not exist (which happens with `pytest` < 7). However, evaluating the `default` for `getattr()` then _guarantees_ that `fspath` is accessed, which is incompatible with `-p no:legacypath`. The simplest way of avoiding accessing `fspath` is to use explicitly version-dependent code.