### PR TITLE
Test wheel with 3.11 until `python-dateutil` is updated for 3.12

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -54,5 +54,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
       test_command: pytest $GITHUB_WORKSPACE/tests; pytest --mpl $GITHUB_WORKSPACE/tests
+      # Remove python-version when python-dateutil >2.8.2
+      python-version: "3.11"
     secrets:
       pypi_token: ${{ secrets.pypi_password }}


### PR DESCRIPTION
https://github.com/dateutil/dateutil/issues/1314 produces a warning via matplotlib in Python 3.12. It's fixed in the dateutil repo so hopefully they can push a new tag soon. We can't ignore the warning in the pytest config as the warning occurs during test collection.