### PR TITLE
MNT: Compat with pytest 8.1

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -42,8 +42,7 @@ jobs:
         - linux: py311-test-mpl36
         - linux: py311-test-mpl37
         # Test different versions of pytest
-        # Skip pytestdev until hook wrapper issue is fixed
-        # - linux: py312-test-mpldev-pytestdev
+        - linux: py312-test-mpldev-pytestdev
         - linux: py39-test-mpl33-pytest62
         - linux: py38-test-mpl31-pytest54
       coverage: 'codecov'

--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -13,6 +13,10 @@ on:
   # Allow manual runs through the web UI
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -58,6 +58,9 @@ SHAPE_MISMATCH_ERROR = """Error: Image dimensions did not match.
     {actual_path}"""
 
 PYTEST_LT_7 = Version(pytest.__version__) < Version("7.0.0")
+PYTEST_GE_8_0 = any([_pytest_version.is_devrelease,
+                     _pytest_version.is_prerelease,
+                     _pytest_version >= Version('8.0')])
 
 # The following are the subsets of formats supported by the Matplotlib image
 # comparison machinery
@@ -128,11 +131,19 @@ def wrap_figure_interceptor(plugin, item):
         item.obj = figure_interceptor(plugin, item.obj)
 
 
-def pytest_report_header(config, startdir):
-    import matplotlib
-    import matplotlib.ft2font
-    return ["Matplotlib: {0}".format(matplotlib.__version__),
-            "Freetype: {0}".format(matplotlib.ft2font.__freetype_version__)]
+if PYTEST_GE_8_0:
+    def pytest_report_header(config, start_path):
+        import matplotlib
+        import matplotlib.ft2font
+        return ["Matplotlib: {0}".format(matplotlib.__version__),
+                "Freetype: {0}".format(matplotlib.ft2font.__freetype_version__)]
+
+else:
+    def pytest_report_header(config, startdir):
+        import matplotlib
+        import matplotlib.ft2font
+        return ["Matplotlib: {0}".format(matplotlib.__version__),
+                "Freetype: {0}".format(matplotlib.ft2font.__freetype_version__)]
 
 
 def pytest_addoption(parser):

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -57,7 +57,8 @@ SHAPE_MISMATCH_ERROR = """Error: Image dimensions did not match.
   Actual shape: {actual_shape}
     {actual_path}"""
 
-PYTEST_LT_7 = Version(pytest.__version__) < Version("7.0.0")
+_pytest_version = Version(pytest.__version__)
+PYTEST_LT_7 = _pytest_version < Version("7.0.0")
 PYTEST_GE_8_0 = any([_pytest_version.is_devrelease,
                      _pytest_version.is_prerelease,
                      _pytest_version >= Version('8.0')])

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -57,11 +57,7 @@ SHAPE_MISMATCH_ERROR = """Error: Image dimensions did not match.
   Actual shape: {actual_shape}
     {actual_path}"""
 
-_pytest_version = Version(pytest.__version__)
-PYTEST_LT_7 = _pytest_version < Version("7.0.0")
-PYTEST_GE_8_0 = any([_pytest_version.is_devrelease,
-                     _pytest_version.is_prerelease,
-                     _pytest_version >= Version('8.0')])
+PYTEST_LT_7 = Version(pytest.__version__) < Version("7.0.0")
 
 # The following are the subsets of formats supported by the Matplotlib image
 # comparison machinery

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,11 +55,11 @@ filterwarnings =
     ignore:The NumPy module was reloaded
 
 [flake8]
-max-line-length = 100
-ignore = W504
+max-line-length = 120
+ignore = W503,W504
 
 [pycodestyle]
-max_line_length = 100
+max_line_length = 120
 
 [isort]
 balanced_wrapping = True


### PR DESCRIPTION
To avoid this in pytest 8.1.dev:

```
pluggy._manager.PluginValidationError: Plugin 'pytest_mpl' for hook 'pytest_report_header'
hookimpl definition: pytest_report_header(config, startdir)
Argument(s) {'startdir'} are declared in the hookimpl but can not be found in the hookspec
```

See https://github.com/pytest-dev/pytest/issues/11779#issuecomment-1879387034

Fix #216 , xref https://github.com/pytest-dev/pytest/issues/11714#issuecomment-1864962140