### PR TITLE
Fix unclosed test files

### DIFF
--- a/tests/test_default_tolerance.py
+++ b/tests/test_default_tolerance.py
@@ -9,11 +9,11 @@ TEST_NAME = "test_base_style"
 @pytest.fixture(scope="module")
 def baseline_image(tmp_path_factory):
     path = Path(__file__).parent / "baseline" / "2.0.x" / f"{TEST_NAME}.png"
-    image = Image.open(path)
-    draw = ImageDraw.Draw(image)
-    draw.rectangle(((0, 0), (100, 100)), fill="red")
-    output = tmp_path_factory.mktemp("data") / f"{TEST_NAME}.png"
-    image.save(output)
+    with Image.open(path) as image:
+        draw = ImageDraw.Draw(image)
+        draw.rectangle(((0, 0), (100, 100)), fill="red")
+        output = tmp_path_factory.mktemp("data") / f"{TEST_NAME}.png"
+        image.save(output)
     return output
 
 

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -113,7 +113,8 @@ def test_config(pytester, file_format, ini, cli, kwarg, success_expected):
                 assert key_in_file
 
     else:  # "eps" or "png"
-        actual_metadata = Image.open(str(baseline_image)).info
+        with Image.open(str(baseline_image)) as image:
+            actual_metadata = image.info
         for k, expected in deterministic_metadata.items():
             actual = actual_metadata.get(k, None)
             if success_expected:  # metadata keys should not be in the file


### PR DESCRIPTION
Fix for
```py
>                   warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
E                   pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
E                   
E                   Traceback (most recent call last):
E                     File "/home/runner/work/pytest-mpl/pytest-mpl/tests/test_deterministic.py", line 116, in test_config
E                       actual_metadata = Image.open(str(baseline_image)).info
E                   ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/pytest-of-runner/pytest-0/test_config34/baseline/test_mpl.png'>
```