### PR TITLE
Integrate imagehash to pytest

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -207,6 +207,20 @@ If its directory does not exist, it will be created along with any missing paren
 Configuring this option disables baseline image comparison.
 If you want to enable both hash and baseline image comparison, which we call :doc:`"hybrid mode" <hybrid_mode>`, you must explicitly set the :ref:`baseline directory configuration option <baseline-dir>`.
 
+Hash method used for hash comparison
+------------------------------------
+| **kwarg**: ``hash_method=<name>``
+| **CLI**: ``--mpl-hash-method=<name>``
+| **INI**: ``mpl-hash-method = <name>``
+| Default: ``sha256``
+
+The hash method to use when generating and comparing hashes. Supported methods are
+``sha256``, ``ahash``, ``phash``, ``phash_simple``, ``dhash``, ``dhash_vertical``,
+``whash``, ``colorhash``, and ``crop_resistant_hash``.
+
+Non-``sha256`` methods require raster formats (``png``) and depend on the
+``ImageHash`` package. ``phash`` may require extra optional dependencies (e.g. SciPy).
+
 .. _controlling-sensitivity:
 
 Controlling the sensitivity of the comparison

--- a/docs/hash_mode.rst
+++ b/docs/hash_mode.rst
@@ -7,6 +7,8 @@ Hash Comparison Mode
 This how-to guide will show you how to use the hash comparison mode of ``pytest-mpl``.
 
 In this mode, the hash of the image is compared to the hash of the baseline image.
+By default, ``pytest-mpl`` uses ``sha256``, but you can configure alternative hash
+methods (e.g. perceptual hashes) via ``hash_method`` or ``--mpl-hash-method``.
 Only the hash value of the baseline image, rather than the full image, needs to be stored in the repository.
 This means that the repository size is reduced, and the images can be regenerated if necessary.
 This approach does however make it more difficult to visually inspect any changes to the images.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -142,7 +142,8 @@ Also see the :doc:`configuration guide <configuration>` for more information on 
 Hash comparison mode
 ^^^^^^^^^^^^^^^^^^^^
 
-Instead of comparing to baseline images, you can instead compare against a JSON library of SHA-256 hashes of the baseline image files.
+Instead of comparing to baseline images, you can instead compare against a JSON library of hashes of the baseline image files.
+By default these are SHA-256 hashes, but you can configure alternative hash methods.
 Pros and cons of this mode are:
 
 - :octicon:`diff-added;1em;sd-text-success` Easy to configure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ pytest_mpl = "pytest_mpl.plugin"
 test = [
     "pytest-cov>=6.0.0",
 ]
+hashes = [
+    "ImageHash>=4.3.1",
+    "scipy>=1.8.0",
+]
 docs = [
     "sphinx>=7.0.0",
     "mpl_sphinx_theme>=3.9.0",


### PR DESCRIPTION
 This PR adds configurable hash methods for pytest-mpl’s hash comparison mode and switches perceptual hashing to use the ImageHash library. A new mpl-hash-  method option is available via CLI, INI, and the mpl_image_compare decorator  (hash_method=), with sha256 remaining the default for backward compatibility.  When a non‑SHA method is selected, hashes are computed through ImageHash  (e.g., phash, ahash, dhash, whash, colorhash, etc.), and those methods are  restricted to raster formats (PNG) to avoid invalid usage with vector formats.The implementation removes the custom pHash code path and centralizes hash method validation and computation in the plugin. Documentation is updated to describe the new configuration option and to clarify that alternative hash methods are supported. A new test exercises hash_method="phash" to verify that perceptual hashes are generated correctly. The project now includes an optional hashes extra that installs ImageHash and its supporting dependencies for users who want perceptual hashes.

Closes #150 #146 #21 